### PR TITLE
docs: clarify outline usage

### DIFF
--- a/docs/dankmaterialshell/custom-themes.mdx
+++ b/docs/dankmaterialshell/custom-themes.mdx
@@ -127,7 +127,7 @@ For themes without light/dark variants, define colors at the top level:
 - `backgroundText` - Text color for background areas
 
 ### Outline
-- `outline` - Border and divider color for subtle boundaries
+- `outline` - Color for subtle borders, dividers, muted icons, and extra subtle text
 
 ## Optional Properties
 


### PR DESCRIPTION
Although it is not specified in Material 3 (as I could see), DMS use outlines for setting toggles, disabled wi-fi and bluetooth icons, and muted text for the launcher prefix field in the settings. I think the description should change