### PR TITLE
fix(index.tsx): fixes /docs/ path to include trailing slash to fix broken links

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -272,7 +272,7 @@ export default function Home() {
                     <path d="M7 4L13 10L7 16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
                   </svg>
                 </Link>
-                <Link to="/docs" className={styles.secondaryCTA}>
+                <Link to="/docs/" className={styles.secondaryCTA}>
                   Documentation
                 </Link>
               </div>


### PR DESCRIPTION
Steps to reproduce the issue:
1. User visits https://danklinux.com/
2. User clicks Documentation
3. User get redirected to https://danklinux.com/docs
4. User clicks any of the links under "The Suite"
4. User get redirected to a "Page not Found" page, because of the missing trailing slash.

example url https://danklinux.com/dankmaterialshell/overview instead of https://danklinux.com/docs/dankmaterialshell/overview

Sidebar links are not broken.