### PR TITLE
Update nixos.mdx with Niri installation warning

### DIFF
--- a/docs/dankgreeter/nixos.mdx
+++ b/docs/dankgreeter/nixos.mdx
@@ -79,7 +79,7 @@ Unlike DankMaterialShell which can be installed via either the NixOS module or h
 
 :::warning
 
-If you are using niri, it must be installed as a NixOS module for it to appear in the login screen. Niri installed via home-manager will not show up in DankGreeter's compositor selection.
+Compositors must be installed via NixOS configuration to appear in DankGreeter, not via home-manager.
 
 :::
 

--- a/docs/dankgreeter/nixos.mdx
+++ b/docs/dankgreeter/nixos.mdx
@@ -77,6 +77,12 @@ Unlike DankMaterialShell which can be installed via either the NixOS module or h
 
 :::
 
+:::warning
+
+If you are using niri, it must be installed as a NixOS module for it to appear in the login screen. Niri installed via home-manager will not show up in DankGreeter's compositor selection.
+
+:::
+
 ## Configuration Options
 
 ```nix


### PR DESCRIPTION
Add warning about Niri installation for DankGreeter warning the user that Niri will not show up in the Greeter's selection menu if it is installed using Home manager.