### PR TITLE
Nix flake: Update documentation to reflect changes to naming style, module structure, and to home-manager settings

### DIFF
--- a/docs/dankgreeter/nixos-flake.mdx
+++ b/docs/dankgreeter/nixos-flake.mdx
@@ -73,7 +73,7 @@ DankGreeter is only available as a NixOS module (not as a home-manager module), 
 Enable and configure the greeter in your NixOS configuration:
 
 ```nix
-programs.dankMaterialShell.greeter = {
+programs.dank-material-shell.greeter = {
   enable = true;
   compositor.name = "niri";  # Or "hyprland" or "sway"
 };
@@ -94,7 +94,7 @@ Compositors must be installed via NixOS configuration to appear in DankGreeter, 
 ## Configuration Options
 
 ```nix
-programs.dankMaterialShell.greeter = {
+programs.dank-material-shell.greeter = {
   compositor = {
     name = "niri"; # Required. Can be also "hyprland" or "sway"
     customConfig = ''

--- a/docs/dankmaterialshell/nixos-flake.mdx
+++ b/docs/dankmaterialshell/nixos-flake.mdx
@@ -123,8 +123,8 @@ You can import and use the niri-specific DankMaterialShell module:
 
 ```nix
 imports = [
-  inputs.dms.homeModules.dank-material-shell.default
-  inputs.dms.homeModules.dank-material-shell.niri
+  inputs.dms.homeModules.dank-material-shell
+  inputs.dms.homeModules.niri
 ];
 ```
 


### PR DESCRIPTION
This documents AvengeMedia/DankMaterialShell#1014 and AvengeMedia/DankMaterialShell#1233.

I looked around at how similar projects document their nix settings and found that noctalia has [this](https://github.com/noctalia-dev/noctalia-docs/blob/main/src/components/SettingsReference.astro), which they use to embed a live updating nix version of their default json settings. I don't know enough about how the backend of these docs works to know how difficult it would be to do this with the SettingsSpec.js and SessionSpec.js files, but it could be nice. For now I have just linked both of those files.