### PR TITLE
Display example image inside notice

### DIFF
--- a/docs/dankmaterialshell/cli-keybinds-cheatsheets.mdx
+++ b/docs/dankmaterialshell/cli-keybinds-cheatsheets.mdx
@@ -55,9 +55,7 @@ dms ipc call keybinds toggle hyprland
 dms ipc call keybinds toggle sway
 dms ipc call keybinds toggle <provider>
 ```
-This opens a modal overlay showing the keybinds in the shell interface.
-:::
-
+This opens a modal overlay showing the keybinds in the shell interface, eg for Hyprland:
 <ThemedImage
   alt="DMS Keybinds UI display"
   sources={{
@@ -66,6 +64,7 @@ This opens a modal overlay showing the keybinds in the shell interface.
   }}
   style={{ maxWidth: '800px', width: '100%', marginTop: '1rem', marginBottom: '1rem' }}
 />
+:::
 
 ## Built-in Providers
 


### PR DESCRIPTION
The instructions were unclear to me, the screenshot below did not suggest to me it was the result of the previously mentioned commands.

So I've put the image inside the notice which should make it clear for anyone.

I couldn't preview this change on my end, since there are no build instructions for the docs - so I hope it is rendering fine inside the notice.