### PR TITLE
fix: admonition title syntax

### DIFF
--- a/docs/contributing-registry.mdx
+++ b/docs/contributing-registry.mdx
@@ -68,7 +68,7 @@ Thank you for contributing to the DankMaterialShell registry! This guide covers 
 | `distro` | Yes | Supported distributions: `["any"]`, `["fedora"]`, `["arch"]`, etc. |
 | `screenshot` | No | Direct URL to a screenshot image |
 
-:::warning Important
+:::warning[Important]
 The `id` and `name` fields **must exactly match** the corresponding fields in your plugin repository's `plugin.json` file.
 :::
 

--- a/docs/dankgreeter/installation.mdx
+++ b/docs/dankgreeter/installation.mdx
@@ -20,7 +20,7 @@ import Hero from '@site/src/components/Hero';
 
 ## Installation Methods
 
-:::note Already have the DankLinux repository?
+:::note[Already have the DankLinux repository?]
 
 If DMS or another DankLinux package is already installed, the repository is already configured. The simplest option is:
 

--- a/docs/dankgreeter/nixos-flake.mdx
+++ b/docs/dankgreeter/nixos-flake.mdx
@@ -19,7 +19,7 @@ import Hero from '@site/src/components/Hero';
 
 DankGreeter can be installed on NixOS using the NixOS module. This guide covers the flake-based installation method.
 
-:::info Native NixOS module Available
+:::info[Native NixOS module Available]
 DankGreeter is now available in nixpkgs unstable! If you're on NixOS unstable (26.05), see [Installation - NixOS](nixos) for the native nixpkgs installation method which doesn't require flakes.
 It is advised to use the Flake option if you want to get quicker updates or if you want to use the home-manager modules.
 
@@ -44,7 +44,7 @@ Add the required flake inputs to your `flake.nix` if you haven't yet:
 }
 ```
 
-:::tip Using Unstable Version
+:::tip[Using Unstable Version]
 If you want to use the unstable (-git) version from the master branch, you can use:
 ```nix
 dms.url = "github:AvengeMedia/DankMaterialShell";

--- a/docs/dankgreeter/nixos.mdx
+++ b/docs/dankgreeter/nixos.mdx
@@ -19,7 +19,7 @@ import Hero from '@site/src/components/Hero';
 
 DankGreeter can be installed on NixOS using the native nixpkgs module. This is the recommended installation method for users on NixOS unstable.
 
-:::info NixOS Unstable Required
+:::info[NixOS Unstable Required]
 DankGreeter is currently only available in the **unstable** branch of nixpkgs. If you're on NixOS stable (currently version 25.11), you'll need to use the [Flake Installation](nixos-flake) method instead.
 :::
 
@@ -110,7 +110,7 @@ First, add the flake input to your `flake.nix`:
 }
 ```
 
-:::tip Using Unstable Version
+:::tip[Using Unstable Version]
 If you want to use the unstable (-git) version from the master branch for quicker updates, remove `/stable` from the URL:
 ```nix
 dms.url = "github:AvengeMedia/DankMaterialShell";

--- a/docs/dankinstall.mdx
+++ b/docs/dankinstall.mdx
@@ -61,7 +61,7 @@ sudo -v && curl -fsSL https://install.danklinux.com | sh -s -- \
   -c hyprland -t kitty --include-deps dms-greeter --replace-configs-all -y
 ```
 
-:::info Logs
+:::info[Logs]
 
 Logs are written to `/tmp/dankinstall-<timestamp>.log`. Set `DANKINSTALL_LOG_DIR` to override the directory.
 

--- a/docs/danklinux/index.mdx
+++ b/docs/danklinux/index.mdx
@@ -49,7 +49,7 @@ DankMaterialShell is now available on more distributions than ever before!
 
 For complete DMS installation instructions including repository setup, see the [DankMaterialShell Installation Guide](../dankmaterialshell/installation).
 
-:::tip Quick Start
+:::tip[Quick Start]
 
 - **Fedora**: See the [Fedora & CentOS](../dankmaterialshell/installation#fedora--centos) section in the installation guide
 - **Ubuntu/Debian**: See the [Ubuntu & Debian](../dankmaterialshell/installation#debian--ubuntu) section in the installation guide

--- a/docs/dankmaterialshell/advanced-configuration.mdx
+++ b/docs/dankmaterialshell/advanced-configuration.mdx
@@ -247,7 +247,7 @@ DMS_IPP_PASSWORD=secret dms run
 
 ## Setting Environment Variables
 
-:::tip Systemd / DankInstall Users
+:::tip[Systemd / DankInstall Users]
 
 If you manage DMS with systemd (including dankinstall users), set environment variables in `~/.config/environment.d/90-dms.conf`:
 

--- a/docs/dankmaterialshell/application-themes.mdx
+++ b/docs/dankmaterialshell/application-themes.mdx
@@ -164,7 +164,7 @@ If you manage your own GTK theme but want DMS colors:
 
 Qt theming offers two approaches: basic GTK passthrough or dedicated Qt control.
 
-:::tip Systemd / DankInstall Users
+:::tip[Systemd / DankInstall Users]
 
 If you installed via dankinstall or manage DMS with systemd, set environment variables in `~/.config/environment.d/90-dms.conf`. For example, to switch to qt6ct:
 
@@ -222,7 +222,7 @@ QT_QPA_PLATFORMTHEME=qt6ct
 
 You can also run `systemctl --user edit dms` and add `Environment=QT_QPA_PLATFORMTHEME=qt6ct` under `[Service]`. This only affects DMS and apps it launches, whereas `90-dms.conf` applies to all user sessions.
 
-:::warning KDE/Plasma Users
+:::warning[KDE/Plasma Users]
 
 Setting `QT_QPA_PLATFORMTHEME` in `environment.d` will break KDE/Plasma sessions. Instead, use `systemctl --user edit dms` and add the environment variable there:
 

--- a/docs/dankmaterialshell/cli-keybinds-cheatsheets.mdx
+++ b/docs/dankmaterialshell/cli-keybinds-cheatsheets.mdx
@@ -48,7 +48,7 @@ dms keybinds show tmux
 dms keybinds show firefox
 ```
 
-:::tip Display in Shell
+:::tip[Display in Shell]
 You can also display keybinds directly within DMS using IPC:
 ```bash
 dms ipc call keybinds toggle hyprland
@@ -259,7 +259,7 @@ binds {
 }
 ```
 
-:::tip Include Order Matters
+:::tip[Include Order Matters]
 - DMS include **before** your binds: Your binds override DMS defaults
 - DMS include **after** your binds: DMS binds take priority
 

--- a/docs/dankmaterialshell/cli-process-management.mdx
+++ b/docs/dankmaterialshell/cli-process-management.mdx
@@ -135,7 +135,7 @@ dms kill
 
 ## Running DMS at Login
 
-:::tip DankInstall Users
+:::tip[DankInstall Users]
 
 If you used [dankinstall](../dankinstall), DMS is already configured as a systemd service and starts automatically. You don't need to configure anything here.
 

--- a/docs/dankmaterialshell/compositors.mdx
+++ b/docs/dankmaterialshell/compositors.mdx
@@ -467,7 +467,7 @@ windowrule=isfloating:1,appid:^org\.quickshell$
 
 ### Key Configuration Sections
 
-:::info Coming Soon
+:::info[Coming Soon]
 
 Detailed Sway configuration sections are coming soon. Sway configuration will include:
 - Startup commands
@@ -501,7 +501,7 @@ For the full list of available IPC commands see [IPC](./keybinds-ipc.mdx). Basic
 
 ### Key Configuration Sections
 
-:::info Coming Soon
+:::info[Coming Soon]
 
 Detailed labwc configuration sections are coming soon. labwc configuration will include:
 - Startup commands
@@ -525,7 +525,7 @@ For the full list of available IPC commands see [IPC](./keybinds-ipc.mdx). labwc
 
 ### Key Configuration Sections
 
-:::info Coming Soon
+:::info[Coming Soon]
 
 Detailed Miracle WM configuration sections are coming soon. Miracle WM configuration will include:
 - Startup commands

--- a/docs/dankmaterialshell/icon-theming.mdx
+++ b/docs/dankmaterialshell/icon-theming.mdx
@@ -155,7 +155,7 @@ Check which platform theme you're currently using:
 echo $QT_QPA_PLATFORMTHEME
 ```
 
-:::tip DankInstall Users
+:::tip[DankInstall Users]
 
 dankinstall sets `QT_QPA_PLATFORMTHEME=gtk3` in `~/.config/environment.d/90-dms.conf`. Check this file to see your current setting. You can also override this per-service with `systemctl --user edit dms` (only affects DMS and apps it launches).
 

--- a/docs/dankmaterialshell/installation.mdx
+++ b/docs/dankmaterialshell/installation.mdx
@@ -312,7 +312,7 @@ sudo zypper install dms-git
 
 ## Gentoo (Community)
 
-:::warning Community Maintained
+:::warning[Community Maintained]
 
 These overlays are maintained by the community, not the DMS team. For issues with the ebuilds, report to the respective overlay repositories.
 
@@ -532,7 +532,7 @@ See [Managing Your Installation](managing) for detailed guidance on service mana
 
 ### Systemd Integration (Recommended)
 
-:::tip DankInstall Users
+:::tip[DankInstall Users]
 
 If you used [dankinstall](../dankinstall), this is already configured. The installer runs `systemctl --user enable --now dms` during setup.
 
@@ -573,7 +573,7 @@ If using systemd autostart, remove `dms run` / `spawn "dms" "run"` / `exec-once=
 
 Different compositors have different levels of systemd session integration. Choose the section that matches your compositor.
 
-:::tip Why use add-wants?
+:::tip[Why use add-wants?]
 
 If you have multiple desktop environments installed (e.g., Plasma, GNOME, niri), using `systemctl --user enable dms` starts DMS in *all* of them. Using `add-wants` binds DMS to a specific compositor's service or session target, so it only runs where you want it. DMS won't launch when you log into Plasma or GNOME.
 

--- a/docs/dankmaterialshell/managing.mdx
+++ b/docs/dankmaterialshell/managing.mdx
@@ -22,7 +22,7 @@ This guide covers how to manage, update, and configure DankMaterialShell after i
 
 DMS can run as a systemd user service or be launched manually. The `dms` CLI handles both transparently - commands like `dms restart` work regardless of how DMS was started.
 
-:::tip DankInstall Users
+:::tip[DankInstall Users]
 
 If you installed via [dankinstall](../dankinstall), DMS is configured as a systemd service by default. The installer runs `systemctl --user enable --now dms` during setup. You don't need to add `dms run` to your compositor config.
 
@@ -134,7 +134,7 @@ dms kill
 
 DMS and its themed applications need certain environment variables set. Where these live depends on your setup.
 
-:::tip DankInstall Users
+:::tip[DankInstall Users]
 
 dankinstall creates `~/.config/environment.d/90-dms.conf` with the necessary variables. This file is loaded by systemd for all user sessions. If you need to change Qt theming (e.g., switching to qt6ct), edit this file.
 

--- a/docs/dankmaterialshell/nixos-flake.mdx
+++ b/docs/dankmaterialshell/nixos-flake.mdx
@@ -18,7 +18,7 @@ import Hero from '@site/src/components/Hero';
 
 DankMaterialShell can be installed on NixOS either system-wide using the NixOS module or per-user using home-manager. This guide covers both flake-based installation methods.
 
-:::info Native nixpkgs Available
+:::info[Native nixpkgs Available]
 DankMaterialShell is now available in nixpkgs unstable! If you're on NixOS unstable (26.05), see [Installation - NixOS](nixos) for the native nixpkgs installation method which doesn't require flakes.
 :::
 
@@ -48,7 +48,7 @@ First, add the required flake inputs to your `flake.nix`:
 }
 ```
 
-:::tip Using Unstable Version
+:::tip[Using Unstable Version]
 If you want to use the unstable (-git) version from the master branch, you can use:
 ```nix
 dms.url = "github:AvengeMedia/DankMaterialShell";
@@ -86,7 +86,7 @@ programs.dank-material-shell.enable = true;
 That's it! Rebuild your system (or standalone home-manager configuration) and DankMaterialShell will be installed  with sensible defaults.
 
 
-:::warning dgop on NixOS Stable
+:::warning[dgop on NixOS Stable]
 `dgop` is not available in nixpkgs stable (25.11). If you're using NixOS stable, you'll need to either:
 - Import dgop from the dgop flake and manually set the package, or
 - Use nixpkgs unstable for dgop
@@ -195,7 +195,7 @@ Also note that this will overwrite your `~/.config/niri/config.kdl`, so your nir
 
 In most cases, it should work out of the box, but configuration options are available.
 
-:::tip Generating Include Files
+:::tip[Generating Include Files]
 The files referenced by `filesToInclude` must exist or niri will error on startup. If you're not generating them through home-manager, use [`dms setup`](cli-setup) to deploy the defaults — or generate individual files like `dms setup binds`, `dms setup colors`, etc.
 :::
 
@@ -265,7 +265,7 @@ programs.dank-material-shell = {
 
 ### Custom Quickshell Package
 
-:::info Quickshell from Source
+:::info[Quickshell from Source]
 
 The DankMaterialShell flake already uses Quickshell built from source by default, as many features rely on unreleased Quickshell features. No additional configuration is needed.
 

--- a/docs/dankmaterialshell/nixos.mdx
+++ b/docs/dankmaterialshell/nixos.mdx
@@ -18,7 +18,7 @@ import Hero from '@site/src/components/Hero';
 
 DankMaterialShell can be installed on NixOS using the NixOS module. This guide covers the native nixpkgs installation method.
 
-:::info NixOS Unstable Required
+:::info[NixOS Unstable Required]
 DankMaterialShell is currently only available in the **unstable** branch of nixpkgs. If you're on NixOS stable (currently 25.11), you'll need to use the [Flake Installation](nixos-flake) method instead.
 :::
 
@@ -91,7 +91,7 @@ programs.dms-shell = {
 
 #### Using Quickshell from Source
 
-:::tip Recommended for Latest Features
+:::tip[Recommended for Latest Features]
 
 Many features in DankMaterialShell rely on unreleased Quickshell features. For the best experience, you may want to use Quickshell built from source.
 
@@ -140,7 +140,7 @@ First, add the flake input to your `flake.nix`:
 }
 ```
 
-:::tip Using Unstable Version
+:::tip[Using Unstable Version]
 If you want to use the unstable (-git) version from the master branch for quicker updates, remove `/stable` from the URL:
 ```nix
 dms.url = "github:AvengeMedia/DankMaterialShell";

--- a/docs/danksearch/installation.mdx
+++ b/docs/danksearch/installation.mdx
@@ -20,7 +20,7 @@ import Hero from '@site/src/components/Hero';
 
 `dsearch` has zero dependencies and compiles to a single static binary.
 
-:::tip NixOS Users
+:::tip[NixOS Users]
 If you're using NixOS, see the dedicated [NixOS Installation guides](nixos-flake) for declarative installation with flakes or native nixpkgs modules.
 :::
 

--- a/docs/danksearch/nixos-flake.mdx
+++ b/docs/danksearch/nixos-flake.mdx
@@ -19,7 +19,7 @@ import Hero from '@site/src/components/Hero';
 
 DankSearch can be installed on NixOS using home-manager with flakes. This guide covers the flake-based installation method for per-user installation.
 
-:::info Native nixpkgs Available
+:::info[Native nixpkgs Available]
 DankSearch is now available in nixpkgs unstable! If you're on NixOS unstable, see [Installation - NixOS](nixos) for the native nixpkgs installation method which doesn't require flakes.
 :::
 

--- a/docs/danksearch/nixos.mdx
+++ b/docs/danksearch/nixos.mdx
@@ -19,7 +19,7 @@ import Hero from '@site/src/components/Hero';
 
 DankSearch can be installed on NixOS using the NixOS module. This guide covers the native nixpkgs installation method.
 
-:::info NixOS Unstable Required
+:::info[NixOS Unstable Required]
 DankSearch is currently only available in the **unstable** branch of nixpkgs. If you're on NixOS stable, you'll need to use the [Flake Installation](nixos-flake) method instead.
 :::
 

--- a/versioned_docs/version-1.2/contributing-registry.mdx
+++ b/versioned_docs/version-1.2/contributing-registry.mdx
@@ -68,7 +68,7 @@ Thank you for contributing to the DankMaterialShell registry! This guide covers 
 | `distro` | Yes | Supported distributions: `["any"]`, `["fedora"]`, `["arch"]`, etc. |
 | `screenshot` | No | Direct URL to a screenshot image |
 
-:::warning Important
+:::warning[Important]
 The `id` and `name` fields **must exactly match** the corresponding fields in your plugin repository's `plugin.json` file.
 :::
 

--- a/versioned_docs/version-1.2/dankgreeter/nixos-flake.mdx
+++ b/versioned_docs/version-1.2/dankgreeter/nixos-flake.mdx
@@ -19,7 +19,7 @@ import Hero from '@site/src/components/Hero';
 
 DankGreeter can be installed on NixOS using the NixOS module. This guide covers the flake-based installation method.
 
-:::info Native NixOS module Available
+:::info[Native NixOS module Available]
 DankGreeter is now available in nixpkgs unstable! If you're on NixOS unstable (26.05), see [Installation - NixOS](nixos) for the native nixpkgs installation method which doesn't require flakes.
 It is advised to use the Flake option if you want to get quicker updates or if you want to use the home-manager modules.
 
@@ -44,7 +44,7 @@ Add the required flake inputs to your `flake.nix` if you haven't yet:
 }
 ```
 
-:::tip Using Unstable Version
+:::tip[Using Unstable Version]
 If you want to use the unstable (-git) version from the master branch, you can use:
 ```nix
 dms.url = "github:AvengeMedia/DankMaterialShell";

--- a/versioned_docs/version-1.2/dankgreeter/nixos.mdx
+++ b/versioned_docs/version-1.2/dankgreeter/nixos.mdx
@@ -19,7 +19,7 @@ import Hero from '@site/src/components/Hero';
 
 DankGreeter can be installed on NixOS using the native nixpkgs module. This is the recommended installation method for users on NixOS unstable.
 
-:::info NixOS Unstable Required
+:::info[NixOS Unstable Required]
 DankGreeter is currently only available in the **unstable** branch of nixpkgs. If you're on NixOS stable (currently version 25.11), you'll need to use the [Flake Installation](nixos-flake) method instead.
 :::
 
@@ -110,7 +110,7 @@ First, add the flake input to your `flake.nix`:
 }
 ```
 
-:::tip Using Unstable Version
+:::tip[Using Unstable Version]
 If you want to use the unstable (-git) version from the master branch for quicker updates, remove `/stable` from the URL:
 ```nix
 dms.url = "github:AvengeMedia/DankMaterialShell";

--- a/versioned_docs/version-1.2/danklinux/index.mdx
+++ b/versioned_docs/version-1.2/danklinux/index.mdx
@@ -49,7 +49,7 @@ DankMaterialShell is now available on more distributions than ever before!
 
 For complete DMS installation instructions including repository setup, see the [DankMaterialShell Installation Guide](../dankmaterialshell/installation).
 
-:::tip Quick Start
+:::tip[Quick Start]
 
 - **Fedora**: See the [Fedora & CentOS](../dankmaterialshell/installation#fedora--centos) section in the installation guide
 - **Ubuntu/Debian**: See the [Ubuntu & Debian](../dankmaterialshell/installation#debian--ubuntu) section in the installation guide

--- a/versioned_docs/version-1.2/dankmaterialshell/advanced-configuration.mdx
+++ b/versioned_docs/version-1.2/dankmaterialshell/advanced-configuration.mdx
@@ -161,7 +161,7 @@ DMS_IPP_PASSWORD=secret dms run
 
 ## Setting Environment Variables
 
-:::tip Systemd / DankInstall Users
+:::tip[Systemd / DankInstall Users]
 
 If you manage DMS with systemd (including dankinstall users), set environment variables in `~/.config/environment.d/90-dms.conf`:
 

--- a/versioned_docs/version-1.2/dankmaterialshell/application-themes.mdx
+++ b/versioned_docs/version-1.2/dankmaterialshell/application-themes.mdx
@@ -164,7 +164,7 @@ If you manage your own GTK theme but want DMS colors:
 
 Qt theming offers two approaches: basic GTK passthrough or dedicated Qt control.
 
-:::tip Systemd / DankInstall Users
+:::tip[Systemd / DankInstall Users]
 
 If you installed via dankinstall or manage DMS with systemd, set environment variables in `~/.config/environment.d/90-dms.conf`. For example, to switch to qt6ct:
 
@@ -218,7 +218,7 @@ If you manage DMS with systemd (including dankinstall users), edit `~/.config/en
 QT_QPA_PLATFORMTHEME=qt6ct
 ```
 
-:::warning KDE/Plasma Users
+:::warning[KDE/Plasma Users]
 
 Setting `QT_QPA_PLATFORMTHEME` in `environment.d` will break KDE/Plasma sessions. Instead, add the environment variable to the DMS systemd service directly:
 

--- a/versioned_docs/version-1.2/dankmaterialshell/cli-keybinds-cheatsheets.mdx
+++ b/versioned_docs/version-1.2/dankmaterialshell/cli-keybinds-cheatsheets.mdx
@@ -48,7 +48,7 @@ dms keybinds show tmux
 dms keybinds show firefox
 ```
 
-:::tip Display in Shell
+:::tip[Display in Shell]
 You can also display keybinds directly within DMS using IPC:
 ```bash
 dms ipc call keybinds toggle hyprland
@@ -260,7 +260,7 @@ binds {
 }
 ```
 
-:::tip Include Order Matters
+:::tip[Include Order Matters]
 - DMS include **before** your binds: Your binds override DMS defaults
 - DMS include **after** your binds: DMS binds take priority
 

--- a/versioned_docs/version-1.2/dankmaterialshell/cli-process-management.mdx
+++ b/versioned_docs/version-1.2/dankmaterialshell/cli-process-management.mdx
@@ -135,7 +135,7 @@ dms kill
 
 ## Running DMS at Login
 
-:::tip DankInstall Users
+:::tip[DankInstall Users]
 
 If you used [dankinstall](../dankinstall), DMS is already configured as a systemd service and starts automatically. You don't need to configure anything here.
 

--- a/versioned_docs/version-1.2/dankmaterialshell/compositors.mdx
+++ b/versioned_docs/version-1.2/dankmaterialshell/compositors.mdx
@@ -514,7 +514,7 @@ windowrule=isfloating:1,appid:^org\.quickshell$
 
 ### Key Configuration Sections
 
-:::info Coming Soon
+:::info[Coming Soon]
 
 Detailed Sway configuration sections are coming soon. Sway configuration will include:
 - Startup commands
@@ -546,7 +546,7 @@ For the full list of available IPC commands see [IPC](./keybinds-ipc.mdx). Basic
 
 ### Key Configuration Sections
 
-:::info Coming Soon
+:::info[Coming Soon]
 
 Detailed labwc configuration sections are coming soon. labwc configuration will include:
 - Startup commands

--- a/versioned_docs/version-1.2/dankmaterialshell/icon-theming.mdx
+++ b/versioned_docs/version-1.2/dankmaterialshell/icon-theming.mdx
@@ -155,7 +155,7 @@ Check which platform theme you're currently using:
 echo $QT_QPA_PLATFORMTHEME
 ```
 
-:::tip DankInstall Users
+:::tip[DankInstall Users]
 
 dankinstall sets `QT_QPA_PLATFORMTHEME=gtk3` in `~/.config/environment.d/90-dms.conf`. Check this file to see your current setting.
 

--- a/versioned_docs/version-1.2/dankmaterialshell/installation.mdx
+++ b/versioned_docs/version-1.2/dankmaterialshell/installation.mdx
@@ -426,7 +426,7 @@ See [Managing Your Installation](managing) for detailed guidance on service mana
 
 ### Systemd Integration (Recommended)
 
-:::tip DankInstall Users
+:::tip[DankInstall Users]
 
 If you used [dankinstall](../dankinstall), this is already configured. The installer runs `systemctl --user enable --now dms` during setup.
 
@@ -467,7 +467,7 @@ If using systemd autostart, remove `dms run` / `spawn "dms" "run"` / `exec-once=
 
 Different compositors have different levels of systemd session integration. Choose the section that matches your compositor.
 
-:::tip Why use add-wants?
+:::tip[Why use add-wants?]
 
 If you have multiple desktop environments installed (e.g., Plasma, GNOME, niri), using `systemctl --user enable dms` starts DMS in *all* of them. Using `add-wants` binds DMS to a specific compositor's service or session target, so it only runs where you want it. DMS won't launch when you log into Plasma or GNOME.
 

--- a/versioned_docs/version-1.2/dankmaterialshell/managing.mdx
+++ b/versioned_docs/version-1.2/dankmaterialshell/managing.mdx
@@ -22,7 +22,7 @@ This guide covers how to manage, update, and configure DankMaterialShell after i
 
 DMS can run as a systemd user service or be launched manually. The `dms` CLI handles both transparently - commands like `dms restart` work regardless of how DMS was started.
 
-:::tip DankInstall Users
+:::tip[DankInstall Users]
 
 If you installed via [dankinstall](../dankinstall), DMS is configured as a systemd service by default. The installer runs `systemctl --user enable --now dms` during setup. You don't need to add `dms run` to your compositor config.
 
@@ -134,7 +134,7 @@ dms kill
 
 DMS and its themed applications need certain environment variables set. Where these live depends on your setup.
 
-:::tip DankInstall Users
+:::tip[DankInstall Users]
 
 dankinstall creates `~/.config/environment.d/90-dms.conf` with the necessary variables. This file is loaded by systemd for all user sessions. If you need to change Qt theming (e.g., switching to qt6ct), edit this file.
 

--- a/versioned_docs/version-1.2/dankmaterialshell/nixos-flake.mdx
+++ b/versioned_docs/version-1.2/dankmaterialshell/nixos-flake.mdx
@@ -18,7 +18,7 @@ import Hero from '@site/src/components/Hero';
 
 DankMaterialShell can be installed on NixOS either system-wide using the NixOS module or per-user using home-manager. This guide covers both flake-based installation methods.
 
-:::info Native nixpkgs Available
+:::info[Native nixpkgs Available]
 DankMaterialShell is now available in nixpkgs unstable! If you're on NixOS unstable (26.05), see [Installation - NixOS](nixos) for the native nixpkgs installation method which doesn't require flakes.
 :::
 
@@ -48,7 +48,7 @@ First, add the required flake inputs to your `flake.nix`:
 }
 ```
 
-:::tip Using Unstable Version
+:::tip[Using Unstable Version]
 If you want to use the unstable (-git) version from the master branch, you can use:
 ```nix
 dms.url = "github:AvengeMedia/DankMaterialShell";
@@ -85,7 +85,7 @@ programs.dank-material-shell.enable = true;
 
 That's it! Rebuild your system (or standalone home-manager configuration) and DankMaterialShell will be installed  with sensible defaults.
 
-:::warning dgop on NixOS Stable
+:::warning[dgop on NixOS Stable]
 `dgop` is not available in nixpkgs stable (25.11). If you're using NixOS stable, you'll need to either:
 - Import dgop from the dgop flake and manually set the package, or
 - Use nixpkgs unstable for dgop
@@ -258,7 +258,7 @@ programs.dank-material-shell = {
 
 ### Custom Quickshell Package
 
-:::info Quickshell from Source
+:::info[Quickshell from Source]
 
 The DankMaterialShell flake already uses Quickshell built from source by default, as many features rely on unreleased Quickshell features. No additional configuration is needed.
 

--- a/versioned_docs/version-1.2/dankmaterialshell/nixos.mdx
+++ b/versioned_docs/version-1.2/dankmaterialshell/nixos.mdx
@@ -22,7 +22,7 @@ DankMaterialShell can be installed on NixOS using the NixOS module. This guide c
 DMS version available in `nixos-unstable` currently is DMS 1.0.3. This page will be updated as soon as [1.2](/blog/v1-2-release) gets updated in `nixpkgs`.
 :::
 
-:::info NixOS Unstable Required
+:::info[NixOS Unstable Required]
 DankMaterialShell is currently only available in the **unstable** branch of nixpkgs. If you're on NixOS stable (currently 25.11), you'll need to use the [Flake Installation](nixos-flake) method instead.
 :::
 
@@ -95,7 +95,7 @@ programs.dms-shell = {
 
 #### Using Quickshell from Source
 
-:::tip Recommended for Latest Features
+:::tip[Recommended for Latest Features]
 
 Many features in DankMaterialShell rely on unreleased Quickshell features. For the best experience, you may want to use Quickshell built from source.
 
@@ -144,7 +144,7 @@ First, add the flake input to your `flake.nix`:
 }
 ```
 
-:::tip Using Unstable Version
+:::tip[Using Unstable Version]
 If you want to use the unstable (-git) version from the master branch for quicker updates, remove `/stable` from the URL:
 ```nix
 dms.url = "github:AvengeMedia/DankMaterialShell";

--- a/versioned_docs/version-1.2/danksearch/installation.mdx
+++ b/versioned_docs/version-1.2/danksearch/installation.mdx
@@ -20,7 +20,7 @@ import Hero from '@site/src/components/Hero';
 
 `dsearch` has zero dependencies and compiles to a single static binary.
 
-:::tip NixOS Users
+:::tip[NixOS Users]
 If you're using NixOS, see the dedicated [NixOS Installation guides](nixos-flake) for declarative installation with flakes or native nixpkgs modules.
 :::
 

--- a/versioned_docs/version-1.2/danksearch/nixos-flake.mdx
+++ b/versioned_docs/version-1.2/danksearch/nixos-flake.mdx
@@ -19,7 +19,7 @@ import Hero from '@site/src/components/Hero';
 
 DankSearch can be installed on NixOS using home-manager with flakes. This guide covers the flake-based installation method for per-user installation.
 
-:::info Native nixpkgs Available
+:::info[Native nixpkgs Available]
 DankSearch is now available in nixpkgs unstable! If you're on NixOS unstable, see [Installation - NixOS](nixos) for the native nixpkgs installation method which doesn't require flakes.
 :::
 

--- a/versioned_docs/version-1.2/danksearch/nixos.mdx
+++ b/versioned_docs/version-1.2/danksearch/nixos.mdx
@@ -19,7 +19,7 @@ import Hero from '@site/src/components/Hero';
 
 DankSearch can be installed on NixOS using the NixOS module. This guide covers the native nixpkgs installation method.
 
-:::info NixOS Unstable Required
+:::info[NixOS Unstable Required]
 DankSearch is currently only available in the **unstable** branch of nixpkgs. If you're on NixOS stable, you'll need to use the [Flake Installation](nixos-flake) method instead.
 :::
 

--- a/versioned_docs/version-1.4/contributing-registry.mdx
+++ b/versioned_docs/version-1.4/contributing-registry.mdx
@@ -68,7 +68,7 @@ Thank you for contributing to the DankMaterialShell registry! This guide covers 
 | `distro` | Yes | Supported distributions: `["any"]`, `["fedora"]`, `["arch"]`, etc. |
 | `screenshot` | No | Direct URL to a screenshot image |
 
-:::warning Important
+:::warning[Important]
 The `id` and `name` fields **must exactly match** the corresponding fields in your plugin repository's `plugin.json` file.
 :::
 

--- a/versioned_docs/version-1.4/dankgreeter/installation.mdx
+++ b/versioned_docs/version-1.4/dankgreeter/installation.mdx
@@ -20,7 +20,7 @@ import Hero from '@site/src/components/Hero';
 
 ## Installation Methods
 
-:::note Already have the DankLinux repository?
+:::note[Already have the DankLinux repository?]
 
 If DMS or another DankLinux package is already installed, the repository is already configured. The simplest option is:
 

--- a/versioned_docs/version-1.4/dankgreeter/nixos-flake.mdx
+++ b/versioned_docs/version-1.4/dankgreeter/nixos-flake.mdx
@@ -19,7 +19,7 @@ import Hero from '@site/src/components/Hero';
 
 DankGreeter can be installed on NixOS using the NixOS module. This guide covers the flake-based installation method.
 
-:::info Native NixOS module Available
+:::info[Native NixOS module Available]
 DankGreeter is now available in nixpkgs unstable! If you're on NixOS unstable (26.05), see [Installation - NixOS](nixos) for the native nixpkgs installation method which doesn't require flakes.
 It is advised to use the Flake option if you want to get quicker updates or if you want to use the home-manager modules.
 
@@ -44,7 +44,7 @@ Add the required flake inputs to your `flake.nix` if you haven't yet:
 }
 ```
 
-:::tip Using Unstable Version
+:::tip[Using Unstable Version]
 If you want to use the unstable (-git) version from the master branch, you can use:
 ```nix
 dms.url = "github:AvengeMedia/DankMaterialShell";

--- a/versioned_docs/version-1.4/dankgreeter/nixos.mdx
+++ b/versioned_docs/version-1.4/dankgreeter/nixos.mdx
@@ -19,7 +19,7 @@ import Hero from '@site/src/components/Hero';
 
 DankGreeter can be installed on NixOS using the native nixpkgs module. This is the recommended installation method for users on NixOS unstable.
 
-:::info NixOS Unstable Required
+:::info[NixOS Unstable Required]
 DankGreeter is currently only available in the **unstable** branch of nixpkgs. If you're on NixOS stable (currently version 25.11), you'll need to use the [Flake Installation](nixos-flake) method instead.
 :::
 
@@ -110,7 +110,7 @@ First, add the flake input to your `flake.nix`:
 }
 ```
 
-:::tip Using Unstable Version
+:::tip[Using Unstable Version]
 If you want to use the unstable (-git) version from the master branch for quicker updates, remove `/stable` from the URL:
 ```nix
 dms.url = "github:AvengeMedia/DankMaterialShell";

--- a/versioned_docs/version-1.4/danklinux/index.mdx
+++ b/versioned_docs/version-1.4/danklinux/index.mdx
@@ -49,7 +49,7 @@ DankMaterialShell is now available on more distributions than ever before!
 
 For complete DMS installation instructions including repository setup, see the [DankMaterialShell Installation Guide](../dankmaterialshell/installation).
 
-:::tip Quick Start
+:::tip[Quick Start]
 
 - **Fedora**: See the [Fedora & CentOS](../dankmaterialshell/installation#fedora--centos) section in the installation guide
 - **Ubuntu/Debian**: See the [Ubuntu & Debian](../dankmaterialshell/installation#debian--ubuntu) section in the installation guide

--- a/versioned_docs/version-1.4/dankmaterialshell/advanced-configuration.mdx
+++ b/versioned_docs/version-1.4/dankmaterialshell/advanced-configuration.mdx
@@ -177,7 +177,7 @@ DMS_IPP_PASSWORD=secret dms run
 
 ## Setting Environment Variables
 
-:::tip Systemd / DankInstall Users
+:::tip[Systemd / DankInstall Users]
 
 If you manage DMS with systemd (including dankinstall users), set environment variables in `~/.config/environment.d/90-dms.conf`:
 

--- a/versioned_docs/version-1.4/dankmaterialshell/application-themes.mdx
+++ b/versioned_docs/version-1.4/dankmaterialshell/application-themes.mdx
@@ -164,7 +164,7 @@ If you manage your own GTK theme but want DMS colors:
 
 Qt theming offers two approaches: basic GTK passthrough or dedicated Qt control.
 
-:::tip Systemd / DankInstall Users
+:::tip[Systemd / DankInstall Users]
 
 If you installed via dankinstall or manage DMS with systemd, set environment variables in `~/.config/environment.d/90-dms.conf`. For example, to switch to qt6ct:
 
@@ -222,7 +222,7 @@ QT_QPA_PLATFORMTHEME=qt6ct
 
 You can also run `systemctl --user edit dms` and add `Environment=QT_QPA_PLATFORMTHEME=qt6ct` under `[Service]`. This only affects DMS and apps it launches, whereas `90-dms.conf` applies to all user sessions.
 
-:::warning KDE/Plasma Users
+:::warning[KDE/Plasma Users]
 
 Setting `QT_QPA_PLATFORMTHEME` in `environment.d` will break KDE/Plasma sessions. Instead, use `systemctl --user edit dms` and add the environment variable there:
 

--- a/versioned_docs/version-1.4/dankmaterialshell/cli-keybinds-cheatsheets.mdx
+++ b/versioned_docs/version-1.4/dankmaterialshell/cli-keybinds-cheatsheets.mdx
@@ -48,7 +48,7 @@ dms keybinds show tmux
 dms keybinds show firefox
 ```
 
-:::tip Display in Shell
+:::tip[Display in Shell]
 You can also display keybinds directly within DMS using IPC:
 ```bash
 dms ipc call keybinds toggle hyprland
@@ -260,7 +260,7 @@ binds {
 }
 ```
 
-:::tip Include Order Matters
+:::tip[Include Order Matters]
 - DMS include **before** your binds: Your binds override DMS defaults
 - DMS include **after** your binds: DMS binds take priority
 

--- a/versioned_docs/version-1.4/dankmaterialshell/cli-process-management.mdx
+++ b/versioned_docs/version-1.4/dankmaterialshell/cli-process-management.mdx
@@ -135,7 +135,7 @@ dms kill
 
 ## Running DMS at Login
 
-:::tip DankInstall Users
+:::tip[DankInstall Users]
 
 If you used [dankinstall](../dankinstall), DMS is already configured as a systemd service and starts automatically. You don't need to configure anything here.
 

--- a/versioned_docs/version-1.4/dankmaterialshell/compositors.mdx
+++ b/versioned_docs/version-1.4/dankmaterialshell/compositors.mdx
@@ -467,7 +467,7 @@ windowrule=isfloating:1,appid:^org\.quickshell$
 
 ### Key Configuration Sections
 
-:::info Coming Soon
+:::info[Coming Soon]
 
 Detailed Sway configuration sections are coming soon. Sway configuration will include:
 - Startup commands
@@ -501,7 +501,7 @@ For the full list of available IPC commands see [IPC](./keybinds-ipc.mdx). Basic
 
 ### Key Configuration Sections
 
-:::info Coming Soon
+:::info[Coming Soon]
 
 Detailed labwc configuration sections are coming soon. labwc configuration will include:
 - Startup commands
@@ -525,7 +525,7 @@ For the full list of available IPC commands see [IPC](./keybinds-ipc.mdx). labwc
 
 ### Key Configuration Sections
 
-:::info Coming Soon
+:::info[Coming Soon]
 
 Detailed Miracle WM configuration sections are coming soon. Miracle WM configuration will include:
 - Startup commands

--- a/versioned_docs/version-1.4/dankmaterialshell/icon-theming.mdx
+++ b/versioned_docs/version-1.4/dankmaterialshell/icon-theming.mdx
@@ -155,7 +155,7 @@ Check which platform theme you're currently using:
 echo $QT_QPA_PLATFORMTHEME
 ```
 
-:::tip DankInstall Users
+:::tip[DankInstall Users]
 
 dankinstall sets `QT_QPA_PLATFORMTHEME=gtk3` in `~/.config/environment.d/90-dms.conf`. Check this file to see your current setting. You can also override this per-service with `systemctl --user edit dms` (only affects DMS and apps it launches).
 

--- a/versioned_docs/version-1.4/dankmaterialshell/installation.mdx
+++ b/versioned_docs/version-1.4/dankmaterialshell/installation.mdx
@@ -312,7 +312,7 @@ sudo zypper install dms-git
 
 ## Gentoo (Community)
 
-:::warning Community Maintained
+:::warning[Community Maintained]
 
 These overlays are maintained by the community, not the DMS team. For issues with the ebuilds, report to the respective overlay repositories.
 
@@ -532,7 +532,7 @@ See [Managing Your Installation](managing) for detailed guidance on service mana
 
 ### Systemd Integration (Recommended)
 
-:::tip DankInstall Users
+:::tip[DankInstall Users]
 
 If you used [dankinstall](../dankinstall), this is already configured. The installer runs `systemctl --user enable --now dms` during setup.
 
@@ -573,7 +573,7 @@ If using systemd autostart, remove `dms run` / `spawn "dms" "run"` / `exec-once=
 
 Different compositors have different levels of systemd session integration. Choose the section that matches your compositor.
 
-:::tip Why use add-wants?
+:::tip[Why use add-wants?]
 
 If you have multiple desktop environments installed (e.g., Plasma, GNOME, niri), using `systemctl --user enable dms` starts DMS in *all* of them. Using `add-wants` binds DMS to a specific compositor's service or session target, so it only runs where you want it. DMS won't launch when you log into Plasma or GNOME.
 

--- a/versioned_docs/version-1.4/dankmaterialshell/managing.mdx
+++ b/versioned_docs/version-1.4/dankmaterialshell/managing.mdx
@@ -22,7 +22,7 @@ This guide covers how to manage, update, and configure DankMaterialShell after i
 
 DMS can run as a systemd user service or be launched manually. The `dms` CLI handles both transparently - commands like `dms restart` work regardless of how DMS was started.
 
-:::tip DankInstall Users
+:::tip[DankInstall Users]
 
 If you installed via [dankinstall](../dankinstall), DMS is configured as a systemd service by default. The installer runs `systemctl --user enable --now dms` during setup. You don't need to add `dms run` to your compositor config.
 
@@ -134,7 +134,7 @@ dms kill
 
 DMS and its themed applications need certain environment variables set. Where these live depends on your setup.
 
-:::tip DankInstall Users
+:::tip[DankInstall Users]
 
 dankinstall creates `~/.config/environment.d/90-dms.conf` with the necessary variables. This file is loaded by systemd for all user sessions. If you need to change Qt theming (e.g., switching to qt6ct), edit this file.
 

--- a/versioned_docs/version-1.4/dankmaterialshell/nixos-flake.mdx
+++ b/versioned_docs/version-1.4/dankmaterialshell/nixos-flake.mdx
@@ -18,7 +18,7 @@ import Hero from '@site/src/components/Hero';
 
 DankMaterialShell can be installed on NixOS either system-wide using the NixOS module or per-user using home-manager. This guide covers both flake-based installation methods.
 
-:::info Native nixpkgs Available
+:::info[Native nixpkgs Available]
 DankMaterialShell is now available in nixpkgs unstable! If you're on NixOS unstable (26.05), see [Installation - NixOS](nixos) for the native nixpkgs installation method which doesn't require flakes.
 :::
 
@@ -48,7 +48,7 @@ First, add the required flake inputs to your `flake.nix`:
 }
 ```
 
-:::tip Using Unstable Version
+:::tip[Using Unstable Version]
 If you want to use the unstable (-git) version from the master branch, you can use:
 ```nix
 dms.url = "github:AvengeMedia/DankMaterialShell";
@@ -86,7 +86,7 @@ programs.dank-material-shell.enable = true;
 That's it! Rebuild your system (or standalone home-manager configuration) and DankMaterialShell will be installed  with sensible defaults.
 
 
-:::warning dgop on NixOS Stable
+:::warning[dgop on NixOS Stable]
 `dgop` is not available in nixpkgs stable (25.11). If you're using NixOS stable, you'll need to either:
 - Import dgop from the dgop flake and manually set the package, or
 - Use nixpkgs unstable for dgop
@@ -195,7 +195,7 @@ Also note that this will overwrite your `~/.config/niri/config.kdl`, so your nir
 
 In most cases, it should work out of the box, but configuration options are available.
 
-:::tip Generating Include Files
+:::tip[Generating Include Files]
 The files referenced by `filesToInclude` must exist or niri will error on startup. If you're not generating them through home-manager, use [`dms setup`](cli-setup) to deploy the defaults — or generate individual files like `dms setup binds`, `dms setup colors`, etc.
 :::
 
@@ -263,7 +263,7 @@ programs.dank-material-shell = {
 
 ### Custom Quickshell Package
 
-:::info Quickshell from Source
+:::info[Quickshell from Source]
 
 The DankMaterialShell flake already uses Quickshell built from source by default, as many features rely on unreleased Quickshell features. No additional configuration is needed.
 

--- a/versioned_docs/version-1.4/dankmaterialshell/nixos.mdx
+++ b/versioned_docs/version-1.4/dankmaterialshell/nixos.mdx
@@ -18,7 +18,7 @@ import Hero from '@site/src/components/Hero';
 
 DankMaterialShell can be installed on NixOS using the NixOS module. This guide covers the native nixpkgs installation method.
 
-:::info NixOS Unstable Required
+:::info[NixOS Unstable Required]
 DankMaterialShell is currently only available in the **unstable** branch of nixpkgs. If you're on NixOS stable (currently 25.11), you'll need to use the [Flake Installation](nixos-flake) method instead.
 :::
 
@@ -91,7 +91,7 @@ programs.dms-shell = {
 
 #### Using Quickshell from Source
 
-:::tip Recommended for Latest Features
+:::tip[Recommended for Latest Features]
 
 Many features in DankMaterialShell rely on unreleased Quickshell features. For the best experience, you may want to use Quickshell built from source.
 
@@ -140,7 +140,7 @@ First, add the flake input to your `flake.nix`:
 }
 ```
 
-:::tip Using Unstable Version
+:::tip[Using Unstable Version]
 If you want to use the unstable (-git) version from the master branch for quicker updates, remove `/stable` from the URL:
 ```nix
 dms.url = "github:AvengeMedia/DankMaterialShell";

--- a/versioned_docs/version-1.4/danksearch/installation.mdx
+++ b/versioned_docs/version-1.4/danksearch/installation.mdx
@@ -20,7 +20,7 @@ import Hero from '@site/src/components/Hero';
 
 `dsearch` has zero dependencies and compiles to a single static binary.
 
-:::tip NixOS Users
+:::tip[NixOS Users]
 If you're using NixOS, see the dedicated [NixOS Installation guides](nixos-flake) for declarative installation with flakes or native nixpkgs modules.
 :::
 

--- a/versioned_docs/version-1.4/danksearch/nixos-flake.mdx
+++ b/versioned_docs/version-1.4/danksearch/nixos-flake.mdx
@@ -19,7 +19,7 @@ import Hero from '@site/src/components/Hero';
 
 DankSearch can be installed on NixOS using home-manager with flakes. This guide covers the flake-based installation method for per-user installation.
 
-:::info Native nixpkgs Available
+:::info[Native nixpkgs Available]
 DankSearch is now available in nixpkgs unstable! If you're on NixOS unstable, see [Installation - NixOS](nixos) for the native nixpkgs installation method which doesn't require flakes.
 :::
 

--- a/versioned_docs/version-1.4/danksearch/nixos.mdx
+++ b/versioned_docs/version-1.4/danksearch/nixos.mdx
@@ -19,7 +19,7 @@ import Hero from '@site/src/components/Hero';
 
 DankSearch can be installed on NixOS using the NixOS module. This guide covers the native nixpkgs installation method.
 
-:::info NixOS Unstable Required
+:::info[NixOS Unstable Required]
 DankSearch is currently only available in the **unstable** branch of nixpkgs. If you're on NixOS stable, you'll need to use the [Flake Installation](nixos-flake) method instead.
 :::
 


### PR DESCRIPTION
cf. https://docusaurus.io/docs/markdown-features/admonitions#specifying-title

fixes *all* ill-formatted admonition titles; addendum to https://github.com/AvengeMedia/DankLinux-Docs/pull/86