### PR TITLE
docs: add section about PAM modules in installation section

### DIFF
--- a/versioned_docs/version-1.2/dankgreeter/installation.mdx
+++ b/versioned_docs/version-1.2/dankgreeter/installation.mdx
@@ -147,6 +147,21 @@ dms greeter status
 
 This verifies your greeter setup and sync status. See the [Configuration guide](/docs/dankgreeter/configuration#checking-sync-status) for detailed information.
 
+#### PAM Modules
+
+DMS Greeter configures PAM automatically, but some features, such as keyring unlocking,  may require additional PAM modules depending on your distribution :
+
+| Distribution  Packages for a couple modules |
+|---|---|
+| Arch Linux | PAM modules are already provided by their respective packages (e.g. `gnome-keyring` |
+| Fedora | `gnome-keyring-pam`, `pam-kwallet`, `fprintd-pam`|
+| Debian/Ubuntu |`libpam-gnome-keyring`, `libpam-kwallet-common`, `libpam-fprintd` |
+| openSUSE | `gnome-keyring-pam`, `pam_kwallet`, `fprintd-pam` |
+| Gentoo | `kwallet-pam`, or the `pam` USE flag for the gnome-keyring and fprint packages |
+| NixOS | `kdePackages.kwallet-pam`, gnome-keyring and fprint include their PAM modules |
+
+After installing the relevant packages, unlocking will work on the next login
+
 ---
 
 ### Manual Setup (all distros)

--- a/versioned_docs/version-1.4/dankgreeter/installation.mdx
+++ b/versioned_docs/version-1.4/dankgreeter/installation.mdx
@@ -288,6 +288,21 @@ dms greeter status
 
 This verifies your greeter setup and sync status. See the [Configuration guide](/docs/dankgreeter/configuration#checking-sync-status) for detailed information.
 
+#### PAM Modules
+
+DMS Greeter configures PAM automatically, but some features, such as keyring unlocking,  may require additional PAM modules depending on your distribution :
+
+| Distribution  Packages for a couple modules |
+|---|---|
+| Arch Linux | PAM modules are already provided by their respective packages (e.g. `gnome-keyring` |
+| Fedora | `gnome-keyring-pam`, `pam-kwallet`, `fprintd-pam`|
+| Debian/Ubuntu |`libpam-gnome-keyring`, `libpam-kwallet-common`, `libpam-fprintd` |
+| openSUSE | `gnome-keyring-pam`, `pam_kwallet`, `fprintd-pam` |
+| Gentoo | `kwallet-pam`, or the `pam` USE flag for the gnome-keyring and fprint packages |
+| NixOS | `kdePackages.kwallet-pam`, gnome-keyring and fprint include their PAM modules |
+
+After installing the relevant packages, unlocking will work on the next login
+
 ---
 
 ### Manual Setup (all distros)


### PR DESCRIPTION
Adds a section to the dankgreeter docs about relevant PAM modules for a few common packages (e.g. gnome-keyring, kwallet, fprint). I matched the distributions that have received installation steps on the wiki, although it is not really necessary for some.
It's currently under [Completing Setup > For all users](https://danklinux.com/docs/dankgreeter/installation#for-all-users).
I am unsure if that is the correct placement for it, it could also make sense under a troubleshooting section at the bottom, or maybe even added more specifically to the installation instructions for every distro.
