### PR TITLE
docs(Installation): Add Solus to installation docs

### DIFF
--- a/docs/dankmaterialshell/installation.mdx
+++ b/docs/dankmaterialshell/installation.mdx
@@ -436,6 +436,20 @@ NixOS has dedicated documentation with two installation methods:
 
 :::
 
+## Solus
+
+DankMaterialShell is available from the official Solus repository. Pair it with `niri`, `hyprland`, `sway`, or `labwc` packages from the official repositories for a complete desktop stack.
+
+```bash
+sudo eopkg install dankmaterialshell
+```
+
+:::tip
+
+Install the `niri-session`, `sway-session`, or 'labwc-session` packages for those compositors to appear in the session list for your greeter.
+
+:::
+
 ## All Other Distributions
 
 :::warning


### PR DESCRIPTION
Adds instructions for installing DankMaterialShell on Solus.
