### PR TITLE
nix: update docs for dms plugin registry

### DIFF
--- a/docs/dankmaterialshell/nixos-flake.mdx
+++ b/docs/dankmaterialshell/nixos-flake.mdx
@@ -346,7 +346,7 @@ Then import the module and enable plugins:
 {
   imports = [
     inputs.dms.homeModules.dank-material-shell
-    inputs.dms-plugin-registry.modules.default
+    inputs.dms-plugin-registry.nixosModules.default
   ];
 
   programs.dank-material-shell = {

--- a/docs/dankmaterialshell/nixos.mdx
+++ b/docs/dankmaterialshell/nixos.mdx
@@ -167,7 +167,7 @@ Then import the module and enable plugins:
 
 ```nix
 {
-  imports = [ inputs.dms-plugin-registry.modules.default ];
+  imports = [ inputs.dms-plugin-registry.nixosModules.default ];
 
   programs.dms-shell = {
     enable = true;

--- a/versioned_docs/version-1.2/dankmaterialshell/nixos-flake.mdx
+++ b/versioned_docs/version-1.2/dankmaterialshell/nixos-flake.mdx
@@ -343,7 +343,7 @@ Then import the module and enable plugins:
 {
   imports = [
     inputs.dms.homeModules.dank-material-shell
-    inputs.dms-plugin-registry.modules.default
+    inputs.dms-plugin-registry.nixosModules.default
   ];
 
   programs.dank-material-shell = {

--- a/versioned_docs/version-1.2/dankmaterialshell/nixos.mdx
+++ b/versioned_docs/version-1.2/dankmaterialshell/nixos.mdx
@@ -194,7 +194,7 @@ Then import the module and enable plugins:
 
 ```nix
 {
-  imports = [ inputs.dms-plugin-registry.modules.default ];
+  imports = [ inputs.dms-plugin-registry.nixosModules.default ];
 
   programs.dms-shell = {
     enable = true;

--- a/versioned_docs/version-1.4/dankmaterialshell/nixos-flake.mdx
+++ b/versioned_docs/version-1.4/dankmaterialshell/nixos-flake.mdx
@@ -340,7 +340,7 @@ Then import the module and enable plugins:
 {
   imports = [
     inputs.dms.homeModules.dank-material-shell
-    inputs.dms-plugin-registry.modules.default
+    inputs.dms-plugin-registry.nixosModules.default
   ];
 
   programs.dank-material-shell = {

--- a/versioned_docs/version-1.4/dankmaterialshell/nixos.mdx
+++ b/versioned_docs/version-1.4/dankmaterialshell/nixos.mdx
@@ -167,7 +167,7 @@ Then import the module and enable plugins:
 
 ```nix
 {
-  imports = [ inputs.dms-plugin-registry.modules.default ];
+  imports = [ inputs.dms-plugin-registry.nixosModules.default ];
 
   programs.dms-shell = {
     enable = true;


### PR DESCRIPTION
Update docs to reflect the changes in AvengeMedia/dms-plugin-registry#287.

This PR replaces all references of `dms-plugin-registry.modules.default` to `dms-plugin-registry.nixosModules.default`.

Updated files:

- `docs/dankmaterialshell/nixos-flake.mdx`
- `docs/dankmaterialshell/nixos.mdx`
- `versioned_docs/version-1.2/dankmaterialshell/nixos-flake.mdx`
- `versioned_docs/version-1.2/dankmaterialshell/nixos.mdx`
- `versioned_docs/version-1.4/dankmaterialshell/nixos-flake.mdx`
- `versioned_docs/version-1.4/dankmaterialshell/nixos.mdx`