### PR TITLE
docs(dankgreeter): document NixOS auto-login

### DIFF
--- a/docs/dankgreeter/nixos.mdx
+++ b/docs/dankgreeter/nixos.mdx
@@ -133,15 +133,6 @@ services.displayManager = {
 `services.displayManager.sessionPackages`) is required — the module needs to
 know which session to start, and will fail to build otherwise.
 
-:::tip
-
-The session launch command is resolved declaratively from your current session
-packages, so it stays correct across rebuilds and won't break after
-`nix-collect-garbage`. Prefer this over the greeter's remembered-session
-auto-login on NixOS.
-
-:::
-
 ## Rebuilding
 
 After making configuration changes, don't forget to rebuild your configuration:

--- a/docs/dankgreeter/nixos.mdx
+++ b/docs/dankgreeter/nixos.mdx
@@ -111,6 +111,37 @@ When using the flake package with the native nixpkgs module, some dependencies m
 
 :::
 
+## Auto-login
+
+DankGreeter can skip the login screen and launch a session automatically on
+boot using the standard NixOS display-manager options:
+
+```nix
+services.displayManager = {
+  autoLogin = {
+    enable = true;
+    user = "yourusername";
+  };
+
+  # Required for auto-login: identifies which session to launch.
+  # Use the .desktop basename without the extension (e.g. "niri", "hyprland").
+  defaultSession = "niri";
+};
+```
+
+`defaultSession` (or at least one entry in
+`services.displayManager.sessionPackages`) is required — the module needs to
+know which session to start, and will fail to build otherwise.
+
+:::tip
+
+The session launch command is resolved declaratively from your current session
+packages, so it stays correct across rebuilds and won't break after
+`nix-collect-garbage`. Prefer this over the greeter's remembered-session
+auto-login on NixOS.
+
+:::
+
 ## Rebuilding
 
 After making configuration changes, don't forget to rebuild your configuration:

--- a/versioned_docs/version-1.4/dankgreeter/nixos.mdx
+++ b/versioned_docs/version-1.4/dankgreeter/nixos.mdx
@@ -111,6 +111,37 @@ When using the flake package with the native nixpkgs module, some dependencies m
 
 :::
 
+## Auto-login
+
+DankGreeter can skip the login screen and launch a session automatically on
+boot using the standard NixOS display-manager options:
+
+```nix
+services.displayManager = {
+  autoLogin = {
+    enable = true;
+    user = "yourusername";
+  };
+
+  # Required for auto-login: identifies which session to launch.
+  # Use the .desktop basename without the extension (e.g. "niri", "hyprland").
+  defaultSession = "niri";
+};
+```
+
+`defaultSession` (or at least one entry in
+`services.displayManager.sessionPackages`) is required — the module needs to
+know which session to start, and will fail to build otherwise.
+
+:::tip
+
+The session launch command is resolved declaratively from your current session
+packages, so it stays correct across rebuilds and won't break after
+`nix-collect-garbage`. Prefer this over the greeter's remembered-session
+auto-login on NixOS.
+
+:::
+
 ## Rebuilding
 
 After making configuration changes, don't forget to rebuild your configuration:


### PR DESCRIPTION
## What

Adds an **Auto-login** section to the DankGreeter NixOS (nixpkgs module) installation page, covering:

- `services.displayManager.autoLogin.enable` / `.user`
- `services.displayManager.defaultSession` (and the requirement that it — or `sessionPackages` — be set)
- a tip noting the session launch command is resolved declaratively, so it survives rebuilds and `nix-collect-garbage`

Applied to both the current page (`docs/dankgreeter/nixos.mdx`) and the latest versioned copy (`versioned_docs/version-1.4/dankgreeter/nixos.mdx`).

## Why

The nixpkgs `dms-greeter` module already supports declarative auto-login (it renders greetd's `initial_session` from these options), but the docs didn't mention it anywhere, so it wasn't discoverable. This is also the durable alternative to the greeter's remembered-session auto-login on NixOS, which can bake an absolute `/nix/store` path that goes stale on rebuild and breaks after garbage collection.

Refs AvengeMedia/DankMaterialShell#2591

> Note: scoped to the nixpkgs module only. The flake module page is intentionally left untouched until the auto-login options are backported there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)