### PR TITLE
Update hyprland config syntax to new lua format

### DIFF
--- a/docs/dankgreeter/configuration.mdx
+++ b/docs/dankgreeter/configuration.mdx
@@ -62,25 +62,27 @@ Custom compositor configurations allow you to configure displays (resolution, re
 
 ### Hyprland
 
-1. Create a baseline configuration file at `/etc/greetd/hypr.conf`:
+1. Create a baseline configuration file at `/etc/greetd/hypr.lua`:
   ```bash
-  sudo tee /etc/greetd/hypr.conf > /dev/null << 'EOF'
-  env = DMS_RUN_GREETER,1
+  sudo tee /etc/greetd/hypr.lua > /dev/null << 'EOF'
+  hl.env("DMS_RUN_GREETER", "1")
 
-  misc {
-      disable_hyprland_logo = true
-  }
+  hl.config({
+      misc = {
+          disable_hyprland_logo = true
+      }
+  })
   EOF
   ```
 
 2. Update the command in `/etc/greetd/config.toml to use this configuration
   ```toml
   #...existing configuration
-  command = "dms-greeter --command hyprland -C /etc/greetd/hypr.conf"
+  command = "dms-greeter --command hyprland -C /etc/greetd/hypr.lua"
   #...existing configuration
   ```
 
-3. Edit `/etc/greetd/hypr.conf` however you see fit, the greeter will run under this compositor configuration
+3. Edit `/etc/greetd/hypr.lua` however you see fit, the greeter will run under this compositor configuration
 
 
 ### Sway

--- a/docs/dankmaterialshell/advanced-configuration.mdx
+++ b/docs/dankmaterialshell/advanced-configuration.mdx
@@ -296,10 +296,10 @@ environment {
 
 Add to your Hyprland config:
 
-```conf
-env = DMS_DISABLE_MATUGEN,1
-env = DMS_DANKBAR_LAYER,overlay
-env = DMS_HIDE_TRAYIDS,discord,spotify
+```lua
+hl.env("DMS_DISABLE_MATUGEN", "1")
+hl.env("DMS_DANKBAR_LAYER", "overlay")
+hl.env("DMS_HIDE_TRAYIDS", "discord,spotify")
 ```
 
 ### Sway

--- a/docs/dankmaterialshell/application-themes.mdx
+++ b/docs/dankmaterialshell/application-themes.mdx
@@ -191,9 +191,9 @@ environment {
 ```
 
 **Hyprland Configuration:**
-```conf
-env = QT_QPA_PLATFORMTHEME,gtk3
-env = QT_QPA_PLATFORMTHEME_QT6,gtk3
+```lua
+hl.env("QT_QPA_PLATFORMTHEME", "gtk3")
+hl.env("QT_QPA_PLATFORMTHEME_QT6", "gtk3")
 ```
 
 ### Option 2: Dedicated Qt Control (Advanced)
@@ -256,9 +256,9 @@ environment {
 ```
 
 **Hyprland:**
-```conf
-env = QT_QPA_PLATFORMTHEME,qt6ct
-env = QT_QPA_PLATFORMTHEME_QT6,qt6ct
+```lua
+hl.env("QT_QPA_PLATFORMTHEME", "qt6ct")
+hl.env("QT_QPA_PLATFORMTHEME_QT6", "qt6ct")
 ```
 
 **Enable Qt Theming:**

--- a/docs/dankmaterialshell/cli-brightness.mdx
+++ b/docs/dankmaterialshell/cli-brightness.mdx
@@ -226,11 +226,11 @@ See the [Keybinds & IPC](/docs/dankmaterialshell/keybinds-ipc#brightness) docume
 
 **Example keybind integration**:
 
-```conf
-# Hyprland example - shows OSD overlay
-bind = , XF86MonBrightnessUp, exec, dms ipc call brightness increment 5
-bind = , XF86MonBrightnessDown, exec, dms ipc call brightness decrement 5
-bind = , XF86MonBrightnessDown+Shift, exec, dms ipc call brightness toggleExponential
+```lua
+-- Hyprland example - shows OSD overlay
+hl.bind("XF86MonBrightnessUp", hl.dsp.exec_cmd("dms ipc call brightness increment 5"))
+hl.bind("XF86MonBrightnessDown", hl.dsp.exec_cmd("dms ipc call brightness decrement 5"))
+hl.bind("SHIFT + XF86MonBrightnessDown", hl.dsp.exec_cmd("dms ipc call brightness toggleExponential"))
 ```
 
 ## Comparison with Other Tools

--- a/docs/dankmaterialshell/cli-doctor.mdx
+++ b/docs/dankmaterialshell/cli-doctor.mdx
@@ -133,6 +133,7 @@ Used to prevent the system from idling or sleeping.
 ### ShortcutInhibitor
 
 Used to manage keyboard shortcuts, specific to the niri compositor.
+
 ---
 
 ## Optional Features

--- a/docs/dankmaterialshell/cli-process-management.mdx
+++ b/docs/dankmaterialshell/cli-process-management.mdx
@@ -168,9 +168,11 @@ If using systemd, don't add `dms run` to your compositor config - you'll end up 
 
 Add to your compositor's autostart configuration:
 
-**Hyprland** (`~/.config/hypr/hyprland.conf`):
-```conf
-exec-once = dms run
+**Hyprland** (`~/.config/hypr/hyprland.lua`):
+```lua
+hl.on("hyprland.start", function()
+    hl.exec_cmd("dms run")
+end)
 ```
 
 **Sway** (`~/.config/sway/config`):

--- a/docs/dankmaterialshell/compositors.mdx
+++ b/docs/dankmaterialshell/compositors.mdx
@@ -193,24 +193,24 @@ window-rule {
 
 ## Hyprland Configuration
 
-Hyprland uses a simple config file format at `~/.config/hypr/hyprland.conf`.
+Hyprland uses a lua based config at `~/.config/hypr/hyprland.lua`.
 
 ### Key Configuration Sections
 
 DMS will automatically apply gaps, window radius, and colors if you include the following files in your Hyprland config. You can customize gaps, border radius, and window radius in **Settings → Compositor**.
 
-```conf
-# Add to the end of ~/.config/hypr/hyprland.conf
-source = ~/.config/hypr/dms/colors.conf
-source = ~/.config/hypr/dms/layout.conf
-source = ~/.config/hypr/dms/outputs.conf
+```lua
+-- Add to the end of ~/.config/hypr/hyprland.lua
+require("dms.colors")
+require("dms.layout")
+require("dms.outputs")
 ```
 
 :::tip
 Be sure that all files exist before including them in the Hyprland configuration.
 ```bash
 mkdir -p ~/.config/hypr/dms
-touch ~/.config/hypr/dms/{colors,layout,outputs}.conf
+touch ~/.config/hypr/dms/{colors,layout,outputs}.lua
 ```
 :::
 
@@ -220,126 +220,138 @@ For manual configuration recommendations, continue below.
 
 For systemd autostart setup (recommended if you have multiple desktop environments), see the [Installation guide](./installation#hyprland). If you prefer not to use systemd, add DMS directly to your Hyprland config:
 
-```conf
-exec-once = dms run
+```lua
+hl.on("hyprland.start", function()
+    hl.exec_cmd("dms run")
 
-# Optional: Clipboard history
-exec-once = bash -c "wl-paste --watch cliphist store &"
+    -- Optional: Clipboard history
+    hl.exec_cmd("bash -c "wl-paste --watch cliphist store &")
+end)
 ```
 
 #### Miscellaneous
 
 Disables the hyprland backdrop/logo
 
-```conf
-misc {
-    disable_hyprland_logo = true
-    disable_splash_rendering = true
-}
+```lua
+hl.config({
+    misc = {
+        disable_hyprland_logo = true,
+        disable_splash_rendering = true
+    }
+})
 ```
 
 #### Environment Variables
 
-```conf
-env = QT_QPA_PLATFORM,wayland
-env = ELECTRON_OZONE_PLATFORM_HINT,auto
-env = QT_QPA_PLATFORMTHEME,gtk3
-env = QT_QPA_PLATFORMTHEME_QT6,gtk3
+```lua
+hl.env("QT_QPA_PLATFORM", "wayland")
+hl.env("QT_QPA_PLATFORMTHEME", "gtk3")
+hl.env("QT_QPA_PLATFORMTHEME_QT6", "gtk3")
+hl.env("ELECTRON_OZONE_PLATFORM_HINT", "auto")
 ```
 
 #### Layer Rules
 
-```conf
-layerrule = no_anim on, match:namespace ^(dms)$
+```lua
+hl.layer_rule({ match = { namespace = "dms" }, no_anim = true })
 ```
 For more about layer rules see [layer rules](./layers.mdx).
 
 #### General Layout
 
-```conf
-general {
-    gaps_in = 5
-    gaps_out = 5
-    border_size = 0
+```lua
+hl.config({
+    general = {
+        gaps_in = 5,
+        gaps_out = 5,
+        border_size = 0,
 
-    col.active_border = rgba(707070ff)
-    col.inactive_border = rgba(d0d0d0ff)
+        col = {
+            active_border = "rgba(707070ff)",
+            inactive_border = "rgba(d0d0d0ff)"
+        },
 
-    layout = dwindle
-}
+        layout = "dwindle"
+    }
+})
 ```
 
 #### Decoration
 
-```conf
-decoration {
-    rounding = 12
+```lua
+hl.config({
+    decoration = {
+        rounding = 12,
 
-    active_opacity = 1.0
-    inactive_opacity = 0.9
+        active_opacity = 1.0,
+        inactive_opacity = 0.9,
 
-    shadow {
-        enabled = true
-        range = 30
-        render_power = 5
-        offset = 0 5
-        color = rgba(00000070)
+        shadow = {
+            enabled = true,
+            range = 30,
+            render_power = 5,
+            offset = {0, 5},
+            color = "rgba(00000070)"
+        }
     }
-}
+})
 ```
 
 #### DMS Keybindings
 
 For the full list of available IPC commands see [IPC](./keybinds-ipc.mdx)
 
-```conf
-$mod = SUPER
+```lua
+local mod = SUPER
 
-# Application Launchers
-bind = $mod, space, exec, dms ipc call spotlight toggle
-bind = $mod, V, exec, dms ipc call clipboard toggle
-bind = $mod, M, exec, dms ipc call processlist focusOrToggle
-bind = $mod, comma, exec, dms ipc call settings focusOrToggle
-bind = $mod, N, exec, dms ipc call notifications toggle
-bind = $mod, Y, exec, dms ipc call dankdash wallpaper
-bind = $mod, TAB, exec, dms ipc call hypr toggleOverview
+-- Application Launchers
+hl.bind(mod .. " + space", hl.dsp.exec_cmd("dms ipc call spotlight toggle")
+hl.bind(mod .. " + V", hl.dsp.exec_cmd("dms ipc call clipboard toggle")
+hl.bind(mod .. " + M", hl.dsp.exec_cmd("dms ipc call processlist focusOrToggle")
+hl.bind(mod .. " + comma", hl.dsp.exec_cmd("dms ipc call settings focusOrToggle")
+hl.bind(mod .. " + N", hl.dsp.exec_cmd("dms ipc call notifications toggle")
+hl.bind(mod .. " + Y", hl.dsp.exec_cmd("dms ipc call dankdash wallpaper")
+hl.bind(mod .. " + TAB", hl.dsp.exec_cmd("dms ipc call hypr toggleOverview")
 
-# Security
-bind = $mod ALT, L, exec, dms ipc call lock lock
+-- Security
+hl.bind(mod .. " + ALT + L", hl.dsp.exec_cmd("dms ipc call lock lock")
 
-# Audio Controls
-bindel = , XF86AudioRaiseVolume, exec, dms ipc call audio increment 3
-bindel = , XF86AudioLowerVolume, exec, dms ipc call audio decrement 3
-bindl = , XF86AudioMute, exec, dms ipc call audio mute
+-- Audio Controls
+hl.bind("XF86AudioRaiseVolume", hl.dsp.exec_cmd("dms ipc call audio increment 3", { locked = true, repeating = true })
+hl.bind("XF86AudioLowerVolume", hl.dsp.exec_cmd("dms ipc call audio decrement 3", { locked = true, repeating = true })
+hl.bind("XF86AudioMute", hl.dsp.exec_cmd("dms ipc call audio mute", { locked = true })
 
-# Brightness Controls
-bindel = , XF86MonBrightnessUp, exec, dms ipc call brightness increment 5
-bindel = , XF86MonBrightnessDown, exec, dms ipc call brightness decrement 5
+-- Brightness Controls
+hl.bind("XF86MonBrightnessUp", hl.dsp.exec_cmd("dms ipc call spotlight toggle", { locked = true, repeating = true })
+hl.bind("XF86MonBrightnessDown", hl.dsp.exec_cmd("dms ipc call spotlight toggle", { locked = true, repeating = true })
 ```
 
 ### Window Rules
 
-```conf
-# Opacity for inactive windows
-windowrule = opacity 0.9 0.9, match:float 0, match:focus 0
+```lua
+-- Opacity for inactive windows
+hl.window_rule({ match = { float = false, focus = false }, opacity = "0.9 0.9" })
 
-# GNOME apps
-windowrule = rounding 12, border_size 0, match:class ^(org\.gnome\.)
+-- GNOME apps
+hl.window_rule({ match = { class = "^(org\\.gnome\\.)" }, border_size = 0, rounding = 12 })
 
-# Terminal apps - no borders
-windowrule = border_size 0, match:class ^(org\.wezfurlong\.wezterm)$
-windowrule = border_size 0, match:class ^(Alacritty)$
-windowrule = border_size 0, match:class ^(zen)$
-windowrule = border_size 0, match:class ^(com\.mitchellh\.ghostty)$
-windowrule = border_size 0, match:class ^(kitty)$
+-- Terminal apps - no borders
+hl.window_rule({ match = { class = "^(org\\.wezfurlong\\.wezterm)$" }, border_size = 0 })
+hl.window_rule({ match = { class = "^(Alacritty)$" }, border_size = 0 })
+hl.window_rule({ match = { class = "^(zen)$" }, border_size = 0 })
+hl.window_rule({ match = { class = "^(com\\.mitchellh\\.ghostty)$" }, border_size = 0 })
+hl.window_rule({ match = { class = "^(kitty)$" }, border_size = 0 })
 
-# Floating windows
-windowrule = float on, match:class ^(gnome-calculator)$
-windowrule = float on, match:class ^(blueman-manager)$
-windowrule = float on, match:class ^(org\.gnome\.Nautilus)$
+-- Floating windows
+hl.window_rule({ match = { class = "^(gnome-calculator)$" }, floating = true })
 
-# Open DMS windows as floating by default
-windowrule = float on, match:class ^(org.quickshell)$
+hl.window_rule({ match = { class = "^(blueman-manager)$" }, floating = true })
+
+hl.window_rule({ match = { class = "^(org\\.gnome\\.Nautilus)$" }, floating = true })
+
+-- Open DMS windows as floating by default
+hl.window_rule({ match = { class = "^(org.quickshell)$" }, floating = true })
 ```
 
 ## MangoWC Configuration
@@ -595,7 +607,7 @@ bindsym XF86MonBrightnessDown exec dms ipc call brightness decrement 5
 
 ### DMS doesn't start automatically
 
-Check your compositor's logs to ensure the `exec-once` or equivalent startup command is running. You can also manually start DMS with `dms run` to see any error messages.
+Check your compositor's logs to ensure the `spawn-at-startup` or equivalent startup command is running. You can also manually start DMS with `dms run` to see any error messages.
 
 ### Keybindings don't work
 

--- a/docs/dankmaterialshell/installation.mdx
+++ b/docs/dankmaterialshell/installation.mdx
@@ -781,9 +781,11 @@ After=graphical-session.target
 
 Add to your Hyprland config (after any `env =` lines):
 
-```conf title="~/.config/hypr/hyprland.conf"
-exec-once = dbus-update-activation-environment --systemd --all
-exec-once = systemctl --user start hyprland-session.target
+```lua title="~/.config/hypr/hyprland.lua"
+hl.on("hyprland.start", function()
+  hl.exec_cmd("dbus-update-activation-environment --systemd --all")
+  hl.exec_cmd("systemctl --user start hyprland-session.target")
+end)
 ```
 
 Bind DMS to the session target:

--- a/docs/dankmaterialshell/layers.mdx
+++ b/docs/dankmaterialshell/layers.mdx
@@ -105,60 +105,60 @@ In order for some layer rules (such as `animation`, `blur` and `dimaround`), you
 
 #### Blur Settings
 
-```conf
-decoration {
-    blur {
-        enabled = true
-        size = 10
-        passes = 4
-
-        ignore_opacity = true
-        new_optimizations = true
-        xray = false
-
-        noise = 0.02
-        contrast = 1.1
-        vibrancy = 0.2
-        vibrancy_darkness = 0.3
-    }
-
-    drop_shadow = true
-    shadow_range = 20
-    shadow_render_power = 3
-    col.shadow = rgba(00000099)
-}
+```lua
+hl.config({
+    decoration = {
+        blur = {
+            enabled = true,
+            size = 10,
+            passes = 4,
+            ignore_opacity = true,
+            new_optimizations = true,
+            xray = false,
+            noise = 0.02,
+            contrast = 1.1,
+            vibrancy = 0.2,
+            vibrancy_darkness = 0.3
+        },
+        shadow = {
+            enabled = true,
+            range = 20,
+            render_power = 3,
+            color = "rgba(00000099)"
+        },
+    },
+})
 ```
 
 #### Layer Rules
 
 Add these layer rules to enable blur for DMS components:
 
-```conf
-# Animations
-layerrule {
-    animation = slide right
-    match:namespace = dms:control-center
-}
+```lua
+hl.layer_rule({
+    match = { namespace = "dms:control-center" },
+    animation = "slide right"
+})
 
-layerrule {
-    animation = slide top
-    match:namespace = dms:workspace-overview
-}
-# You can find all available animations here: https://wiki.hypr.land/Configuring/Animations/#animation-tree
+hl.layer_rule({
+    match= { namespace = "dms:workspace-overview" },
+    animation = "slide top"
+})
+-- You can find all available animations here: https://wiki.hypr.land/Configuring/Advanced-and-Cool/Animations/#animation-tree
 
-# Blur
-# You can use match:namespace with regex to target multiple layers
-layerrule {
-    blur = on
+-- Blur
+-- You can use match.namespace with regex to target multiple layers
+hl.layer_rule({
+    match = { namespace = "dms:(color-picker|clipboard|spotlight|settings)" },
+    blur = true,
     ignore_alpha = 0
-    match:namespace = dms:(color-picker|clipboard|spotlight|settings)
-}
+})
 
-# Dim (if you prefer a dim instead of a blur effect)
-layerrule {
-    dimaround = on
-    match:namespace = dms:(color-picker|clipboard|spotlight|settings)
-}
+-- Dim (if you prefer a dim instead of a blur effect)
+hl.layer_rule({
+    match = { namespace = "dms:(color-picker|clipboard|spotlight|settings)" },
+    dim_around = true
+})
 ```
 #### Examples
 
@@ -167,20 +167,20 @@ layerrule {
 ##### Add a blur effect on the shell's Components
 
 Lower the shell's components' opacity in **Theme & Colors**>**Widget Styling**.
-```conf
-# Modals
-layerrule {
-    blur = on
+```lua
+-- Modals
+hl.layer_rule({
+    match = { namespace = "dms:(polkit|notification-center-modal|workspace-overview|color-picker|clipboard|spotlight|settings|process-list-modal)" },
+    blur = true,
     ignore_alpha = 0
-    match:namespace = dms:(polkit|notification-center-modal|workspace-overview|color-picker|clipboard|spotlight|settings|process-list-modal)
-}
+})
 
-# Shell components (bar, popouts, etc.)
-layerrule {
-    blur = on
+-- Shell components (bar, popouts, etc.)
+hl.layer_rule({
+    match = { namespace = "dms:(bar|tooltip|toast|dock-context-menu|tray-menu-window|control-center|notification-center-popout|dash|system-update|process-list-popout|battery|popout|app-launcher)" },
+    blur = true,
     ignore_alpha = 0
-    match:namespace = dms:(bar|tooltip|toast|dock-context-menu|tray-menu-window|control-center|notification-center-popout|dash|system-update|process-list-popout|battery|popout|app-launcher)
-}
+})
 ```
 </details>
 #### Performance Tuning

--- a/docs/dankmaterialshell/managing.mdx
+++ b/docs/dankmaterialshell/managing.mdx
@@ -90,8 +90,10 @@ For testing, debugging, or if you prefer compositor-managed startup:
 **Compositor autostart:**
 
 ```bash
-# Hyprland (~/.config/hypr/hyprland.conf)
-exec-once = dms run
+# Hyprland (~/.config/hypr/hyprland.lua)
+hl.on("hyprland.start", function()
+  hl.exec_cmd("dms run")
+end)
 
 # Sway (~/.config/sway/config)
 exec dms run
@@ -165,11 +167,11 @@ environment {
 }
 ```
 
-**Hyprland** (`~/.config/hypr/hyprland.conf`):
-```conf
-env = QT_QPA_PLATFORM,wayland
-env = QT_QPA_PLATFORMTHEME,gtk3
-env = ELECTRON_OZONE_PLATFORM_HINT,auto
+**Hyprland** (`~/.config/hypr/hyprland.lua`):
+```lua
+hl.env("QT_QPA_PLATFORM", "wayland")
+hl.env("QT_QPA_PLATFORMTHEME", "gtk3")
+hl.env("ELECTRON_OZONE_PLATFORM_HINT", "auto")
 ```
 
 Or create `~/.config/environment.d/90-dms.conf`:


### PR DESCRIPTION
Updates all the deprecated hyprland syntax to the new lua format, and fixes a link + style problem