### PR TITLE
Update Gentoo Installation instructions

### DIFF
--- a/docs/dankmaterialshell/installation.mdx
+++ b/docs/dankmaterialshell/installation.mdx
@@ -397,20 +397,17 @@ These overlays are maintained by the community, not the DMS team. For issues wit
 
 :::
 
-DankMaterialShell is available on Gentoo through various community overlays.
+DankMaterialShell is available on Gentoo through the GURU overlay.
 
-<Tabs groupId="dms-channel">
-<TabItem value="stable" label="Stable Release" default>
-
-### guru (Recommended)
-
-Enable the official [guru](https://wiki.gentoo.org/wiki/Project:GURU) overlay, which packages DMS (`gui-apps/dankmaterialshell`) alongside companion tools `gui-apps/dgop` and `gui-apps/danksearch`.
+Enable the official [GURU](https://wiki.gentoo.org/wiki/Project:GURU) overlay, which packages DMS (`gui-apps/dankmaterialshell`) alongside companion tools `gui-apps/dgop` and `gui-apps/danksearch`.
 
 ```bash
 sudo eselect repository enable guru
 sudo emaint sync -r guru
-sudo emerge --ask gui-apps/dankmaterialshell
 ```
+
+<Tabs groupId="dms-channel">
+<TabItem value="stable" label="Stable Release" default>
 
 :::note
 
@@ -422,65 +419,30 @@ echo "gui-apps/dankmaterialshell ~amd64" | sudo tee -a /etc/portage/package.acce
 
 :::
 
-### Alternative Overlays
-
-If you prefer not to use `guru`, you can use one of these alternative stable overlays:
-
-<Tabs groupId="gentoo-alternative-stable">
-<TabItem value="tdgentoo" label="tdgentoo" default>
-
-Provides a versioned ebuild (`gui-wm/DankMaterialShell`) pinned to stable releases:
+Finally emerge the package 
 
 ```bash
-sudo eselect repository add tdgentoo git https://github.com/timdodge/tdgentoo.git
-sudo emaint sync -r tdgentoo
-sudo emerge --ask gui-wm/DankMaterialShell
+sudo emerge --ask gui-apps/dankmaterialshell
 ```
-
-</TabItem>
-<TabItem value="dacyberduck" label="dacyberduck">
-
-Provides DMS under `dank-base/dankmaterialshell`:
-
-```bash
-sudo eselect repository add dacyberduck git https://codeberg.org/dacyberduck/gentoo-overlay.git
-sudo emaint sync -r dacyberduck
-sudo emerge --ask dank-base/dankmaterialshell
-```
-
-</TabItem>
-</Tabs>
 
 </TabItem>
 <TabItem value="git" label="Latest Development Build">
 
-### quilat-overlay
+:::note
 
-Provides a live ebuild (`gui-shell/dms-9999`) tracking git master with OpenRC and systemd support.
-
-```bash
-sudo eselect repository add quilat-overlay git https://github.com/Graght/quilat-overlay.git
-sudo emaint sync -r quilat-overlay
-```
-
-Choose the appropriate command for your init system:
-
-<Tabs groupId="gentoo-init">
-<TabItem value="systemd" label="systemd" default>
+The live packages are not keyworded , so you will need to set keywords to `**` for the package. For example:
 
 ```bash
-sudo emerge --ask gui-shell/dms
+echo "gui-apps/dankmaterialshell **" | sudo tee -a /etc/portage/package.accept_keywords/dankmaterialshell
 ```
 
-</TabItem>
-<TabItem value="openrc" label="OpenRC">
+:::
+
+Finally emerge the package 
 
 ```bash
-sudo USE="-systemd" emerge --ask gui-shell/dms
+sudo emerge --ask gui-apps/dankmaterialshell
 ```
-
-</TabItem>
-</Tabs>
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-1.5/dankmaterialshell/installation.mdx
+++ b/versioned_docs/version-1.5/dankmaterialshell/installation.mdx
@@ -397,20 +397,17 @@ These overlays are maintained by the community, not the DMS team. For issues wit
 
 :::
 
-DankMaterialShell is available on Gentoo through various community overlays.
+DankMaterialShell is available on Gentoo through the GURU overlay.
 
-<Tabs groupId="dms-channel">
-<TabItem value="stable" label="Stable Release" default>
-
-### guru (Recommended)
-
-Enable the official [guru](https://wiki.gentoo.org/wiki/Project:GURU) overlay, which packages DMS (`gui-apps/dankmaterialshell`) alongside companion tools `gui-apps/dgop` and `gui-apps/danksearch`.
+Enable the official [GURU](https://wiki.gentoo.org/wiki/Project:GURU) overlay, which packages DMS (`gui-apps/dankmaterialshell`) alongside companion tools `gui-apps/dgop` and `gui-apps/danksearch`.
 
 ```bash
 sudo eselect repository enable guru
 sudo emaint sync -r guru
-sudo emerge --ask gui-apps/dankmaterialshell
 ```
+
+<Tabs groupId="dms-channel">
+<TabItem value="stable" label="Stable Release" default>
 
 :::note
 
@@ -422,65 +419,30 @@ echo "gui-apps/dankmaterialshell ~amd64" | sudo tee -a /etc/portage/package.acce
 
 :::
 
-### Alternative Overlays
-
-If you prefer not to use `guru`, you can use one of these alternative stable overlays:
-
-<Tabs groupId="gentoo-alternative-stable">
-<TabItem value="tdgentoo" label="tdgentoo" default>
-
-Provides a versioned ebuild (`gui-wm/DankMaterialShell`) pinned to stable releases:
+Finally emerge the package 
 
 ```bash
-sudo eselect repository add tdgentoo git https://github.com/timdodge/tdgentoo.git
-sudo emaint sync -r tdgentoo
-sudo emerge --ask gui-wm/DankMaterialShell
+sudo emerge --ask gui-apps/dankmaterialshell
 ```
-
-</TabItem>
-<TabItem value="dacyberduck" label="dacyberduck">
-
-Provides DMS under `dank-base/dankmaterialshell`:
-
-```bash
-sudo eselect repository add dacyberduck git https://codeberg.org/dacyberduck/gentoo-overlay.git
-sudo emaint sync -r dacyberduck
-sudo emerge --ask dank-base/dankmaterialshell
-```
-
-</TabItem>
-</Tabs>
 
 </TabItem>
 <TabItem value="git" label="Latest Development Build">
 
-### quilat-overlay
+:::note
 
-Provides a live ebuild (`gui-shell/dms-9999`) tracking git master with OpenRC and systemd support.
-
-```bash
-sudo eselect repository add quilat-overlay git https://github.com/Graght/quilat-overlay.git
-sudo emaint sync -r quilat-overlay
-```
-
-Choose the appropriate command for your init system:
-
-<Tabs groupId="gentoo-init">
-<TabItem value="systemd" label="systemd" default>
+The live packages are not keyworded , so you will need to set keywords to `**` for the package. For example:
 
 ```bash
-sudo emerge --ask gui-shell/dms
+echo "gui-apps/dankmaterialshell **" | sudo tee -a /etc/portage/package.accept_keywords/dankmaterialshell
 ```
 
-</TabItem>
-<TabItem value="openrc" label="OpenRC">
+:::
+
+Finally emerge the package 
 
 ```bash
-sudo USE="-systemd" emerge --ask gui-shell/dms
+sudo emerge --ask gui-apps/dankmaterialshell
 ```
-
-</TabItem>
-</Tabs>
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Update gentoo install instructions to refere users to the offical gentoo user repository, for both stable and git versions, instead of recommeding user repositories

GURU is an offical gentoo project with user reviews It doesn't really make sense to recommend other repositories, when a package exists in GURU, where it is reviewed and any gentoo user can contribute to it