### PR TITLE
docs(dms): document qtengine as a Qt platform theme option

### DIFF
--- a/docs/dankmaterialshell/application-themes.mdx
+++ b/docs/dankmaterialshell/application-themes.mdx
@@ -129,6 +129,7 @@ When matugen is enabled, theme files are always generated regardless of the "App
 - `~/.config/gtk-4.0/dank-colors.css`
 - `~/.config/qt5ct/colors/matugen.conf`
 - `~/.config/qt6ct/colors/matugen.conf`
+- `~/.config/qtengine/config.json` (when `QT_QPA_PLATFORMTHEME=qtengine`)
 
 The "Apply GTK/Qt Themes" toggles only control whether DankMaterialShell manages the symlinks to make applications use these files.
 
@@ -162,7 +163,7 @@ If you manage your own GTK theme but want DMS colors:
 
 ## Qt Applications
 
-Qt theming offers two approaches: basic GTK passthrough or dedicated Qt control.
+Qt theming offers three approaches: basic GTK passthrough, dedicated Qt control via qt6ct, or qtengine for both Qt5 and Qt6.
 
 :::tip[Systemd / DankInstall Users]
 
@@ -269,15 +270,99 @@ hl.env("QT_QPA_PLATFORMTHEME_QT6", "qt6ct")
 
 This links the generated matugen color files to qt5ct/qt6ct configurations.
 
+### Option 3: qtengine
+
+[qtengine](https://github.com/kossLAN/qtengine) is a single platform theme plugin that serves both Qt5 and Qt6, so it needs neither the qt5ct/qt6ct split nor `qt6ct-kde`.
+
+Worth considering if qt6ct's menu positioning bug affects you, or if GTK passthrough leaves your Qt applications without the matugen accent color.
+
+**Install qtengine:**
+
+```bash
+# Arch
+paru -S qtengine
+
+# Other distributions
+# Follow instructions at https://github.com/kossLAN/qtengine
+```
+
+**Configure Environment:**
+
+One value covers both toolkits, so no `QT_QPA_PLATFORMTHEME_QT6` is needed.
+
+If you manage DMS with systemd (including dankinstall users), edit `~/.config/environment.d/90-dms.conf`:
+```ini
+QT_QPA_PLATFORMTHEME=qtengine
+```
+
+You can also run `systemctl --user edit dms` and add `Environment=QT_QPA_PLATFORMTHEME=qtengine` under `[Service]`. This only affects DMS and apps it launches, whereas `90-dms.conf` applies to all user sessions.
+
+:::warning[KDE/Plasma Users]
+
+Setting `QT_QPA_PLATFORMTHEME` in `environment.d` will break KDE/Plasma sessions. Instead, use `systemctl --user edit dms` and add the environment variable there:
+
+```bash
+systemctl --user edit dms
+```
+
+Add the following:
+
+```ini
+[Service]
+Environment=QT_QPA_PLATFORMTHEME=qtengine
+```
+
+Then restart:
+
+```bash
+systemctl --user restart dms.service
+```
+
+:::
+
+Otherwise, add to your compositor config:
+
+**niri:**
+```kdl
+environment {
+  QT_QPA_PLATFORMTHEME "qtengine"
+}
+```
+
+**Hyprland:**
+```lua
+hl.env("QT_QPA_PLATFORMTHEME", "qtengine")
+```
+
+**Enable Qt Theming:**
+
+1. Log out and back in, or restart your compositor
+2. Open **Settings → Theme & Colors**
+3. Leave **qtengine** enabled under the matugen templates
+
+DMS then writes `~/.config/qtengine/config.json` on every theme change, pointing it at the generated color scheme and keeping the icon theme in sync. Running applications repaint on their own; no restart needed.
+
+Settings you put in that file yourself are preserved. DMS only manages `theme.colorScheme` and `theme.iconTheme`, so `theme.style`, the font entries and the `misc` block stay as you left them.
+
+:::warning[Arch: Qt5 plugin path]
+
+The AUR package installs the Qt5 plugin to `/usr/lib/qt5/plugins/platformthemes/`, but Arch's Qt5 plugin root is `/usr/lib/qt/plugins` with no `5`. Qt5 applications will not find it and fall back to an unthemed palette, while Qt6 applications look correct. Run `dms doctor` to check, and either symlink the plugin into the right directory or add the packaged path to `QT_PLUGIN_PATH`.
+
+:::
+
 ### Dolphin File Manager
 
-Dolphin requires `qt6ct-kde` (not standard `qt6ct`) for proper color theming. With standard `qt6ct`, Dolphin's colors will render poorly.
+Dolphin requires `qt6ct-kde` or `qtengine` (not standard `qt6ct`) for proper color theming. With standard `qt6ct`, Dolphin's colors will render poorly.
+
+**With qtengine:**
+
+Nothing to configure. qtengine supplies the generated color scheme through the platform theme itself, so Dolphin and other KDE applications pick it up the same way they would follow a Plasma color scheme.
 
 **With qt6ct-kde installed:**
 
 Set the color scheme to **Dank Shell (matugen)** in qt6ct's Appearance tab under KColorScheme.
 
-**Alternative (if qt6ct-kde is unavailable):**
+**Alternative (if neither is available):**
 
 Create `~/.config/dolphinrc`:
 


### PR DESCRIPTION
Adds qtengine as Option 3 alongside GTK passthrough and qt6ct, notes the Arch Qt5 plugin-path trap, and records that Dolphin needs no extra configuration under it.