### PR TITLE
docs(ipc): idle inhibit persists across restarts, plus the two undocumented verbs

### DIFF
--- a/docs/dankmaterialshell/keybinds-ipc.mdx
+++ b/docs/dankmaterialshell/keybinds-ipc.mdx
@@ -226,12 +226,21 @@ Idle inhibitor control to prevent automatic sleep/lock.
 | `toggle` | Toggle idle inhibit state |
 | `enable` | Enable idle inhibit (prevent sleep) |
 | `disable` | Disable idle inhibit (allow sleep) |
+| `status` | Report whether idle inhibit is currently enabled |
+| `reason <text>` | Set the inhibit reason; pass an empty string to read the current one |
 
 **Examples:**
 ```bash
 dms ipc call inhibit toggle
 dms ipc call inhibit enable
+dms ipc call inhibit status
+dms ipc call inhibit reason "rendering a video"
+dms ipc call inhibit reason ""   # prints the current reason
 ```
+
+The state is saved in the session, like Do Not Disturb, so it survives a shell
+restart — whether that comes from `dms restart` or from systemd bringing the
+service back.
 
 ### powerprofile
 


### PR DESCRIPTION
Companion to AvengeMedia/DankMaterialShell#3123, which makes the idle inhibitor survive a shell restart.

**Persistence.** Before that change the inhibitor lived only in memory, so `dms restart` — or systemd bringing the service back under `Restart=on-failure` — silently turned it off. Worth stating in the docs, because "Keep Awake" that quietly stops keeping the machine awake is the kind of thing you only notice once the screen has locked.

**Two missing verbs.** While in this section: `inhibit` implements five functions and the table listed three. Both additions were checked against a running shell rather than read off the source:

```
dms ipc call inhibit status      → Idle inhibit is enabled
dms ipc call inhibit reason ""   → Current reason: Keep system awake
```

`reason` is documented as taking a required argument because the CLI rejects the bare form (`Too few arguments provided`) even though the QML handler treats an empty string as a read — so the empty string is the documented way to query it.

Edited `docs/` only, not `versioned_docs/`: the persistence change lands in a release that has not been cut yet. Happy to split the two verbs into their own PR if you would rather keep this one to the persistence note.
