### PR TITLE
docs(dms): document qt6ct vs qt6ct-kde and the doctor plugin check

### DIFF
--- a/docs/dankmaterialshell/cli-doctor.mdx
+++ b/docs/dankmaterialshell/cli-doctor.mdx
@@ -305,7 +305,6 @@ Required for the Dank Greeter. (See [DankGreeter documentation](../dankgreeter/)
 ## Environment Variables
 
 ### QT_QPA_PLATFORMTHEME
-### QT_QPA_PLATFORMTHEME
 
 Used to set the Qt platform theme - usually one of `gtk3`, `qt6ct`, or `kde`. This will define how QT applications are themed. Including some elements of DMS (such as icon themes)
 

--- a/docs/dankmaterialshell/cli-doctor.mdx
+++ b/docs/dankmaterialshell/cli-doctor.mdx
@@ -305,8 +305,15 @@ Required for the Dank Greeter. (See [DankGreeter documentation](../dankgreeter/)
 ## Environment Variables
 
 ### QT_QPA_PLATFORMTHEME
+### QT_QPA_PLATFORMTHEME
 
 Used to set the Qt platform theme - usually one of `gtk3`, `qt6ct`, or `kde`. This will define how QT applications are themed. Including some elements of DMS (such as icon themes)
+
+:::warning[qt6ct vs qt6ct-kde]
+`qt6ct-kde` is the **package name** (AUR), not a theme value — the value Qt expects is `qt6ct`. With `qt6ct-kde` set as the value, Qt apps load no platform theme at all: palettes stay unstyled and icon lookups fail, which shows up in Quickshell tray menus as black/magenta placeholder icons. `dms doctor` flags this misconfiguration and prints the fix.
+:::
+
+When the variable is set, `dms doctor` also verifies that the plugin it names actually exists in the plugin directory Qt searches (asked via `qmake`/`qtpaths`), warning with the expected path on a miss. Without Qt development tools installed, the check reports "Cannot verify" instead of guessing.
 
 ### QS_ICON_THEME
 

--- a/versioned_docs/version-1.5/dankmaterialshell/cli-doctor.mdx
+++ b/versioned_docs/version-1.5/dankmaterialshell/cli-doctor.mdx
@@ -264,8 +264,15 @@ Required for the Dank Greeter. (See [DankGreeter documentation](../dankgreeter/)
 ## Environment Variables
 
 ### QT_QPA_PLATFORMTHEME
+### QT_QPA_PLATFORMTHEME
 
 Used to set the Qt platform theme - usually one of `gtk3`, `qt6ct`, or `kde`. This will define how QT applications are themed. Including some elements of DMS (such as icon themes)
+
+:::warning[qt6ct vs qt6ct-kde]
+`qt6ct-kde` is the **package name** (AUR), not a theme value — the value Qt expects is `qt6ct`. With `qt6ct-kde` set as the value, Qt apps load no platform theme at all: palettes stay unstyled and icon lookups fail, which shows up in Quickshell tray menus as black/magenta placeholder icons. `dms doctor` flags this misconfiguration and prints the fix.
+:::
+
+When the variable is set, `dms doctor` also verifies that the plugin it names actually exists in the plugin directory Qt searches (asked via `qmake`/`qtpaths`), warning with the expected path on a miss. Without Qt development tools installed, the check reports "Cannot verify" instead of guessing.
 
 ### QS_ICON_THEME
 


### PR DESCRIPTION
Companion to AvengeMedia/DankMaterialShell#3240, which adds a `dms doctor` check validating `QT_QPA_PLATFORMTHEME` / `QT_QPA_PLATFORMTHEME_QT6` (the trigger: `qt6ct-kde` — the AUR package name — set as the theme value passes as healthy today, leaving Qt apps without a platform theme and Quickshell tray menus full of placeholder icons).

This documents, in both the current docs and `version-1.5`:

- the `qt6ct` vs `qt6ct-kde` package/value distinction, with the visible failure mode (unstyled palettes, black/magenta placeholder icons in tray menus);
- the doctor behavior introduced by the code PR: the named plugin is verified against the plugin directory Qt actually searches (via `qmake`/`qtpaths`), with a no-false-alarm "Cannot verify" degradation when Qt development tools are absent.

Admonition style matches existing `:::warning[Title]` usage in the repo.
