### PR TITLE
docs(display): per-output ICC color profiles and color temperature

### DIFF
--- a/docs/dankmaterialshell/cli-icc.mdx
+++ b/docs/dankmaterialshell/cli-icc.mdx
@@ -49,7 +49,7 @@ dms icc remove DP-1
 | `dms icc info <file>` | Show details of an ICC/ICM file (description, version, color space, vcgt) |
 | `dms icc apply <output> <file>` | Apply a profile to a specific output |
 | `dms icc remove <output>` | Remove the profile from a specific output |
-| `dms icc set-temp <output> <kelvin>` | Set the reference white point of an output (1000-10000K); `0` removes the override and assumes 6500K |
+| `dms icc set-temp <output> <kelvin>` | Set a per-output color temperature (1000-10000K), independently of the night light schedule; `0` removes the override |
 
 Profiles are looked up in the DMS config directory for the running compositor, `<config dir>/<compositor>/dms/icc` — for example `~/.config/niri/dms/icc` on niri, `~/.config/hypr/dms/icc` on Hyprland and `~/.config/mango/dms/icc` on MangoWC. Output names are connector names as reported by the compositor, such as `DP-1`, `DP-2`, `HDMI-A-1` or `eDP-1`.
 
@@ -58,11 +58,11 @@ Profiles are looked up in the DMS config directory for the running compositor, `
 Display Config → each output card carries both controls:
 
 - **Color Profile** — browse to a `.icc`/`.icm` file and apply it. The row shows the profile description together with version, color space and whether the ramp is currently active; the remove button clears the assignment.
-- **Color Temp** — an independent 3000K–10000K reference white point per output. For an output with a profile this is the white point the profile was produced at (for example a display calibrated at 7000K): the profile is applied as measured, and the night light shifts from that reference instead of assuming 6500K. Outputs without a profile use it as their color temperature directly.
+- **Color Temp** — an independent 3000K–10000K temperature per output, applied independently of the night light schedule, so each display can keep its own white point and its own on/off state (the value is per output, and the range is wider than the night light's). For an output with a profile the temperature is composed on top of the profile ramp, which is treated as measured at 6500K; setting it back to `Default` turns the override off.
 
 Both settings apply immediately and survive restarts.
 
-The reference white point only changes what is rendered when the night light asks for a temperature different from it: with the schedule disabled, a profiled output keeps the ramp its profile describes.
+Per-output values win over the night light schedule: a display with its own temperature keeps it whether the schedule is enabled or not, while displays without one follow the schedule and fall back to 6500K when it is disabled.
 
 ## Configuration
 

--- a/docs/dankmaterialshell/cli-icc.mdx
+++ b/docs/dankmaterialshell/cli-icc.mdx
@@ -49,7 +49,7 @@ dms icc remove DP-1
 | `dms icc info <file>` | Show details of an ICC/ICM file (description, version, color space, vcgt) |
 | `dms icc apply <output> <file>` | Apply a profile to a specific output |
 | `dms icc remove <output>` | Remove the profile from a specific output |
-| `dms icc set-temp <output> <kelvin>` | Set a per-output color temperature (1000-10000K); `0` removes the override so the output follows the night light schedule again |
+| `dms icc set-temp <output> <kelvin>` | Set the reference white point of an output (1000-10000K); `0` removes the override and assumes 6500K |
 
 Profiles are looked up in the DMS config directory for the running compositor, `<config dir>/<compositor>/dms/icc` — for example `~/.config/niri/dms/icc` on niri, `~/.config/hypr/dms/icc` on Hyprland and `~/.config/mango/dms/icc` on MangoWC. Output names are connector names as reported by the compositor, such as `DP-1`, `DP-2`, `HDMI-A-1` or `eDP-1`.
 
@@ -58,9 +58,11 @@ Profiles are looked up in the DMS config directory for the running compositor, `
 Display Config → each output card carries both controls:
 
 - **Color Profile** — browse to a `.icc`/`.icm` file and apply it. The row shows the profile description together with version, color space and whether the ramp is currently active; the remove button clears the assignment.
-- **Color Temp** — an independent 3000K–10000K slider per output. This is useful when a profile was measured at a specific white point (for example a display calibrated at 7000K), or to correct a single monitor without shifting the others.
+- **Color Temp** — an independent 3000K–10000K reference white point per output. For an output with a profile this is the white point the profile was produced at (for example a display calibrated at 7000K): the profile is applied as measured, and the night light shifts from that reference instead of assuming 6500K. Outputs without a profile use it as their color temperature directly.
 
 Both settings apply immediately and survive restarts.
+
+The reference white point only changes what is rendered when the night light asks for a temperature different from it: with the schedule disabled, a profiled output keeps the ramp its profile describes.
 
 ## Configuration
 

--- a/docs/dankmaterialshell/cli-icc.mdx
+++ b/docs/dankmaterialshell/cli-icc.mdx
@@ -32,6 +32,10 @@ dms icc apply DP-1 ~/profiles/display.icm
 # Show what is active right now
 dms icc status
 
+# Set a per-output color temperature, and go back to the schedule later
+dms icc set-temp DP-1 7000
+dms icc set-temp DP-1 0
+
 # Remove the assignment again
 dms icc remove DP-1
 ```
@@ -41,12 +45,13 @@ dms icc remove DP-1
 | Command | Description |
 |---------|-------------|
 | `dms icc list` | List profiles found in the profile directory together with the current assignments |
-| `dms icc status` | Show per output the profile, version, color space and whether the ramp is active |
+| `dms icc status` | Show per output the profile, version, color space, whether the ramp is active and the temperature override |
 | `dms icc info <file>` | Show details of an ICC/ICM file (description, version, color space, vcgt) |
 | `dms icc apply <output> <file>` | Apply a profile to a specific output |
 | `dms icc remove <output>` | Remove the profile from a specific output |
+| `dms icc set-temp <output> <kelvin>` | Set a per-output color temperature (1000-10000K); `0` removes the override so the output follows the night light schedule again |
 
-Profiles are looked up in `<config dir>/niri/dms/icc` (for example `~/.config/niri/dms/icc`). Output names are connector names as reported by the compositor, such as `DP-1`, `DP-2`, `HDMI-A-1` or `eDP-1`.
+Profiles are looked up in the DMS config directory for the running compositor, `<config dir>/<compositor>/dms/icc` — for example `~/.config/niri/dms/icc` on niri, `~/.config/hypr/dms/icc` on Hyprland and `~/.config/mango/dms/icc` on MangoWC. Output names are connector names as reported by the compositor, such as `DP-1`, `DP-2`, `HDMI-A-1` or `eDP-1`.
 
 ## Settings UI
 
@@ -59,7 +64,7 @@ Both settings apply immediately and survive restarts.
 
 ## Configuration
 
-Assignments live in the night light configuration at `~/.config/niri/dms/wayland.json`:
+Assignments live in the night light configuration of the running compositor, `~/.config/niri/dms/wayland.json` on niri (Hyprland and MangoWC use their own directory):
 
 ```json
 {

--- a/docs/dankmaterialshell/cli-icc.mdx
+++ b/docs/dankmaterialshell/cli-icc.mdx
@@ -1,0 +1,85 @@
+---
+title: ICC Color Profiles
+description: Apply per-monitor ICC profiles and set an independent color temperature for each output
+---
+
+import Hero from '@site/src/components/Hero';
+
+<Hero
+  asciiArt={` ██╗ ██████╗ ██████╗
+ ██║██╔════╝██╔════╝
+ ██║██║     ██║     
+ ██║██║     ██║     
+ ██║╚██████╗╚██████╗
+ ╚═╝ ╚═════╝ ╚═════╝`}
+  hideTitle={true}
+/>
+
+The `dms icc` command applies ICC color profiles per output and manages per-output color temperature, on top of the global night light schedule. Both use `wlr-gamma-control-unstable-v1`, the same protocol the night light relies on.
+
+## Quick Start
+
+```bash
+# Show profiles in the profile directory and their current assignments
+dms icc list
+
+# Inspect a profile before applying it
+dms icc info ~/profiles/display.icm
+
+# Apply it to one output
+dms icc apply DP-1 ~/profiles/display.icm
+
+# Show what is active right now
+dms icc status
+
+# Remove the assignment again
+dms icc remove DP-1
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `dms icc list` | List profiles found in the profile directory together with the current assignments |
+| `dms icc status` | Show per output the profile, version, color space and whether the ramp is active |
+| `dms icc info <file>` | Show details of an ICC/ICM file (description, version, color space, vcgt) |
+| `dms icc apply <output> <file>` | Apply a profile to a specific output |
+| `dms icc remove <output>` | Remove the profile from a specific output |
+
+Profiles are looked up in `<config dir>/niri/dms/icc` (for example `~/.config/niri/dms/icc`). Output names are connector names as reported by the compositor, such as `DP-1`, `DP-2`, `HDMI-A-1` or `eDP-1`.
+
+## Settings UI
+
+Display Config → each output card carries both controls:
+
+- **Color Profile** — browse to a `.icc`/`.icm` file and apply it. The row shows the profile description together with version, color space and whether the ramp is currently active; the remove button clears the assignment.
+- **Color Temp** — an independent 3000K–10000K slider per output. This is useful when a profile was measured at a specific white point (for example a display calibrated at 7000K), or to correct a single monitor without shifting the others.
+
+Both settings apply immediately and survive restarts.
+
+## Configuration
+
+Assignments live in the night light configuration at `~/.config/niri/dms/wayland.json`:
+
+```json
+{
+  "iccProfiles": {
+    "DP-1": "/home/user/profiles/display.icm",
+    "eDP-1": "/home/user/profiles/laptop.icm"
+  },
+  "outputTemps": {
+    "DP-1": 7000,
+    "eDP-1": 6500
+  }
+}
+```
+
+`iccProfiles` maps an output name to the profile path, `outputTemps` maps an output name to its color temperature in Kelvin.
+
+## Notes
+
+- ICC ramps are applied even while the night light schedule is disabled: outputs with a profile get their measured ramp, outputs without one stay at an identity ramp so nothing is tinted unexpectedly.
+- Profiles are re-applied after resume and when an output is hot-plugged.
+- The compositor must expose `wlr-gamma-control-unstable-v1`. If `dms icc status` shows no outputs, the running compositor does not provide it.
+- Profiles carrying a `vcgt` tag blend the video card gamma table with the profile tone curves; profiles without one use the TRC curves directly.
+- Night light contrast, gamma and schedule settings in the same file keep working as before; ICC and per-output temperature are applied in addition to them.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -93,6 +93,11 @@ const sidebars: SidebarsConfig = {
             'dankmaterialshell/cli-brightness',
             {
               type: 'doc',
+              id: 'dankmaterialshell/cli-icc',
+              label: 'ICC Color Profiles',
+            },
+            {
+              type: 'doc',
               id: 'dankmaterialshell/cli-clipboard',
               label: 'Clipboard Manager',
             },


### PR DESCRIPTION
## Summary

Documents the per-output ICC color profile and per-output color temperature support added in AvengeMedia/DankMaterialShell#3388.

- **New page**: `docs/dankmaterialshell/cli-icc.mdx` — "ICC Color Profiles":
  - `dms icc` commands (`list`, `status`, `info`, `apply`, `remove`) with examples
  - Settings UI: the **Color Profile** row (browse/apply/remove, showing description, version, color space, active state) and the per-output **Color Temp** slider (3000K–10000K)
  - Configuration keys `iccProfiles` / `outputTemps` in `~/.config/niri/dms/wayland.json`
  - Behavior notes: ramps apply while the night light schedule is disabled, profiles re-apply on hotplug and after resume, `wlr-gamma-control-unstable-v1` required, `vcgt` handling
- **`sidebars.ts`**: registers the page under DankMaterialShell → CLI, after Brightness.

## Related

- AvengeMedia/DankMaterialShell#3388 — feature pull request
