### PR TITLE
docs(dms): document VPN profiles and Fortinet browser login

### DIFF
--- a/docs/dankmaterialshell/cli-doctor.mdx
+++ b/docs/dankmaterialshell/cli-doctor.mdx
@@ -253,16 +253,17 @@ Required for GlobalProtect VPN connections that use SAML (browser-based) authent
 
 ### openconnect
 
-Required for GlobalProtect SAML VPN connections and Fortinet VPN profiles that use password authentication.
+Required for GlobalProtect SAML VPN connections and for Fortinet VPN profiles.
 
 - For GlobalProtect SAML, [openconnect](https://gitlab.com/openconnect/openconnect) converts the prelogin cookie from `gp-saml-gui` into an authentication cookie that NetworkManager can use.
 - For Fortinet password profiles started from the DMS VPN widget, DMS uses `openconnect --authenticate` directly and passes the short-lived cookie to NetworkManager. If the VPN server certificate is not trusted, DMS displays its fingerprint for confirmation and saves the approved fingerprint only after the tunnel connects successfully.
+- For Fortinet profiles that authenticate against an external identity provider, DMS runs the browser login itself and hands the resulting session to NetworkManager.
+
+The NetworkManager openconnect plugin provides the tunnel in every one of those cases, and importing an `openfortivpn` config requires it too. It is packaged separately from the `openconnect` command; see [VPN](vpn#plugins-and-packages) for the package names, and [VPN](vpn) for connecting and importing profiles.
 
 :::note
-Native Fortinet authentication currently applies to profiles with `protocol=fortinet` and `authtype=password`. OTP/MFA challenge forms and other OpenConnect protocols are not included in this flow.
+Native Fortinet authentication applies to profiles with `protocol=fortinet` using either `authtype=password` or `authtype=saml`. Password profiles do not handle OTP or MFA challenge forms; with browser login, any MFA your identity provider asks for happens in the browser. Other OpenConnect protocols are not included in this flow.
 :::
-
-![Fortinet VPN server certificate confirmation in DMS](/img/fortinet-certificate-prompt.png)
 
 ### danksearch
 

--- a/docs/dankmaterialshell/vpn.mdx
+++ b/docs/dankmaterialshell/vpn.mdx
@@ -1,0 +1,207 @@
+---
+title: VPN
+description: Import and connect VPN profiles, including Fortinet gateways that authenticate through a browser
+sidebar_position: 5
+---
+
+import Hero from '@site/src/components/Hero';
+
+<Hero
+  asciiArt={`██████╗ ███╗   ███╗███████╗
+██╔══██╗████╗ ████║██╔════╝
+██║  ██║██╔████╔██║███████╗
+██║  ██║██║╚██╔╝██║╚════██║
+██████╔╝██║ ╚═╝ ██║███████║
+╚═════╝ ╚═╝     ╚═╝╚══════╝`}
+  hideTitle={true}
+/>
+
+DMS manages VPN connections through NetworkManager. Profiles are ordinary NetworkManager
+connections, so anything you import in DMS also works from `nmcli`, GNOME, or KDE, and
+anything those tools created shows up in DMS.
+
+:::note
+VPN requires the NetworkManager backend. `iwd` and `systemd-networkd` have no VPN support.
+See [System Diagnostics](cli-doctor#network) for what each backend covers.
+:::
+
+Profiles are listed in two places, both of which can connect, disconnect, import, and
+delete:
+
+- **Control Center → VPN**
+- **Settings → Network → VPN**
+
+## Plugins and packages
+
+NetworkManager handles most VPN types through plugins, one per protocol, and a profile
+only works when its plugin is installed. WireGuard is the exception, since NetworkManager
+supports it directly.
+
+A plugin package is its prefix followed by the plugin name, which the import table
+below gives for each format:
+
+| Distribution | Prefix |
+|------|---------|
+| Arch, NixOS | `networkmanager-` |
+| Debian, Ubuntu | `network-manager-` |
+| Fedora, openSUSE | `NetworkManager-` |
+
+Fortinet gateways need the openconnect plugin, and importing an `openfortivpn` config
+requires it too, so Fedora installs `NetworkManager-openconnect` and Debian installs
+`network-manager-openconnect`. On NixOS, add the package to
+`networking.networkmanager.plugins` rather than to your system packages.
+
+The `openconnect` command is packaged separately, under that name on every distribution,
+and is a different thing from the plugin. Fortinet profiles that authenticate with a password
+need both, because DMS runs that login through the command. Browser login needs only the
+plugin, since DMS performs the login itself.
+
+## Importing a profile
+
+**Import VPN** opens a file browser. The profile takes its name from the file, and omits
+the extension.
+
+### What can be imported
+
+| Format | Usual file | Handled by |
+| --- | --- | --- |
+| OpenVPN | `.ovpn`, `.conf` | NetworkManager, `openvpn` plugin |
+| WireGuard | `wg-quick` `.conf` | NetworkManager itself, no plugin needed |
+| Cisco (vpnc) | `.pcf`, `.conf` | NetworkManager, `vpnc` plugin |
+| strongSwan | `.sswan`, `.conf` | NetworkManager, `strongswan` plugin |
+| PPTP, L2TP | `.conf` | NetworkManager, matching plugin |
+| openfortivpn | config file, usually with no extension | DMS, see [below](#openfortivpn-configs) |
+
+Apart from `openfortivpn` configs, importing is NetworkManager's own, so the syntax
+each format accepts is whatever NetworkManager accepts, and a format only works when
+its [plugin](#plugins-and-packages) is installed. DMS offers the file to each importer
+in turn and keeps the first profile that comes back.
+
+Two things people reasonably expect to import but cannot. A `.nmconnection` keyfile is
+not an import format; copy it into `/etc/NetworkManager/system-connections` instead, with
+`root` ownership and mode `600`. GlobalProtect has no config file to import, so those
+profiles are created in NetworkManager directly.
+
+### `openfortivpn` configs
+
+An `openfortivpn` config becomes an OpenConnect profile using the Fortinet protocol.
+`openfortivpn` itself is not needed and never runs. The config file is only a source of
+settings, and the tunnel comes from OpenConnect's own Fortinet support.
+
+These keys are read, and everything else in the file is ignored, since the remaining
+options only affect how `openfortivpn` runs `ppp`:
+
+| Key | Becomes |
+| --- | --- |
+| `host` | Gateway host |
+| `port` | Gateway port, `443` when absent |
+| `username` | Login username |
+| `password` | Saved connection password |
+| `realm` | OpenConnect user group |
+| `trusted-cert` | Trusted server certificate, one line per certificate |
+| `saml-login` | Browser login, and the port the gateway redirects to |
+
+`saml-login` must carry a port, unlike the command line flag where it is optional.
+`8020` is the conventional value and what gateways normally redirect to.
+
+How the file authenticates decides what kind of profile you get:
+
+- **With a `saml-login` line**, the profile logs in through the browser. A password in
+  the same file is dropped, because that login never uses one.
+- **Without one**, the profile uses password authentication and keeps whatever
+  credentials the file carried. Missing ones are asked for when you connect.
+
+A password moves out of the plain-text config and into NetworkManager's own storage,
+which is where the rest of your saved connection secrets already live.
+
+## Fortinet gateways
+
+The tunnel comes from the openconnect plugin, so a Fortinet profile needs the
+[packages above](#plugins-and-packages).
+
+### Browser login
+
+Many Fortinet gateways authenticate against an external identity provider, which means
+there is no password to type into DMS. Connecting to such a profile runs the login for
+you:
+
+1. DMS checks the gateway certificate, and asks you to confirm it if it is not already
+   trusted.
+2. Your browser opens on the gateway's login page.
+3. You sign in to whatever identity provider your organisation uses.
+4. The gateway sends the browser back to DMS, which trades the result for the session
+   the tunnel needs.
+
+DMS listens on `127.0.0.1` for step 4, on port `8020` by default. This is the port
+`openfortivpn` uses, and the one gateways are normally configured to redirect to. An
+imported `saml-login` line sets it per profile. To change it afterwards:
+
+```bash
+nmcli connection modify <profile> +vpn.data saml-port=8020
+```
+
+Nothing is left running once the login finishes. The listener is closed as soon as the
+gateway responds, and the tunnel itself is handled by NetworkManager.
+
+### Password login
+
+Profiles that authenticate with a username and password connect through the same
+OpenConnect path DMS already used, prompting for whichever credential is not saved.
+
+## Server certificates
+
+Fortinet gateways commonly present a certificate your system does not trust on its own.
+The first connection to such a gateway shows the fingerprint and waits for you to
+confirm it.
+
+![Fortinet VPN server certificate confirmation in DMS](/img/fortinet-certificate-prompt.png)
+
+An approved certificate is remembered on the profile in the same format an
+`openfortivpn` `trusted-cert` line uses, so a certificate you approve in DMS stays
+usable with `openfortivpn`, and a `trusted-cert` line you imported is honoured on the
+first connect.
+Approving a certificate adds to that list rather than replacing it, which keeps gateways
+that answer from more than one node working.
+
+:::warning
+Certificate approval is only remembered when the connection was started from DMS.
+Started from `nmcli`, a desktop applet, or autoconnect, the approval applies to that one
+connection and the prompt returns next time.
+:::
+
+## GlobalProtect gateways
+
+GlobalProtect profiles that use SAML authenticate through
+[gp-saml-gui](https://github.com/dlenski/gp-saml-gui), which DMS launches to open a
+browser window and then captures the resulting cookie. See
+[System Diagnostics](cli-doctor#gp-saml-gui) for the dependency.
+
+## Troubleshooting
+
+### The import failed
+
+The format needs a plugin you do not have. `openfortivpn` configs and any other
+OpenConnect profile need the [openconnect plugin](#plugins-and-packages); the rest need
+the plugin named in the import table.
+
+### No browser opened
+
+DMS opens the login page with `xdg-open`. Check that a default browser is set:
+
+```bash
+xdg-settings get default-web-browser
+```
+
+### The browser signs in but the connection never starts
+
+The gateway is redirecting to a port DMS is not listening on. Compare the port in the
+gateway's SAML configuration with the profile's:
+
+```bash
+nmcli connection show <profile> | grep saml-port
+```
+
+### The certificate prompt comes back every time
+
+The connection is being started outside DMS. Connect from the Control Center or from
+Settings once, and the approval is saved to the profile.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -47,6 +47,7 @@ const sidebars: SidebarsConfig = {
         },
         'dankmaterialshell/calendar-integration',
         'dankmaterialshell/lock-screen-authentication',
+        'dankmaterialshell/vpn',
         {
           type: 'doc',
           id: 'dankmaterialshell/managing',


### PR DESCRIPTION
Documents the Fortinet VPN support added in AvengeMedia/DankMaterialShell#3384, and corrects a note here that the change makes wrong.

## New page: VPN

There was nowhere to describe importing a profile or connecting to a gateway that authenticates in a browser, so this adds `dankmaterialshell/vpn`, placed after Lock Screen Authentication.

It covers:

- **Plugins and packages.** NetworkManager handles VPN types through plugins, and a profile only works when its plugin is installed. The package name is a per-distribution prefix followed by the plugin name, given as a table, with the openconnect plugin spelled out since that is the one the new feature needs. The `openconnect` command is a separate package from the plugin, which is easy to miss.
- **Importing.** What can be imported, as a table of formats. openfortivpn configs are converted by DMS; everything else goes to NetworkManager's own importers. Also the two things people try that do not work, a `.nmconnection` keyfile and GlobalProtect.
- **openfortivpn configs.** Which keys are read and what each becomes. A `saml-login` line selects the browser login and its password is dropped; without one the profile uses password authentication and keeps the credentials the file carried. openfortivpn itself is never needed and never runs.
- **Fortinet gateways.** The browser login sequence, the loopback port and how to change it, and the password path.
- **Server certificates.** Trust is stored in the same format an openfortivpn `trusted-cert` line uses, and approving a certificate appends rather than replaces. Includes the limitation that approval is only remembered for connections started from DMS.
- **GlobalProtect and troubleshooting.**

## Correction on the diagnostics page

The `openconnect` section said native Fortinet authentication applies only to profiles with `authtype=password`. That is no longer true, so the note now names both authentication types, and says that with browser login any MFA happens at the identity provider rather than in a challenge form.

The section also gains a bullet for the browser login and a pointer to the new page for package names.

## Notes for reviewers

- **Why a new page rather than more of the diagnostics page.** The Fortinet material that exists today sits in that page's dependency sections, which describe things `dms doctor` does not actually check, and the note this PR corrects went stale there. Adding the browser login, the import rules and certificate storage would turn a diagnostics reference into a feature guide. If you would rather keep everything in one place, moving it back and dropping the new page is a small change.
- This targets `docs/` only, which is the unreleased 1.7 documentation. The feature is not in 1.6, so `versioned_docs/` is untouched.
- I moved the certificate prompt screenshot from the diagnostics page to the new page, where the certificate behaviour is now described in full. Happy to keep it in both places if you would rather.
- Please do not merge before AvengeMedia/DankMaterialShell#3384 lands, since the page describes behaviour that does not exist yet.
- `npm run build` passes, which is what catches the cross-page anchor links.

Written with Claude Code; I directed the structure and checked the behaviour it describes against the implementation, including testing how openfortivpn itself parses a `saml-login` line.
