### PR TITLE
Fix: Update Fedora COPR reference for Hyprland in docs

### DIFF
--- a/docs/dankinstall.mdx
+++ b/docs/dankinstall.mdx
@@ -116,7 +116,7 @@ If you're using archinstall, the `minimal` profile with `NetworkManager` for net
 
 **Supported:** Fedora, Nobara, Fedora Asahi Remix
 
-Almost everything comes from official repos or COPR repositories (`avengemedia/danklinux`, `avengemedia/dms`, `solopasha/hyprland`, `niri-wm/niri`). Only dgop needs to be built from source with Go.
+Almost everything comes from official repos or COPR repositories (`avengemedia/danklinux`, `avengemedia/dms`, `lionheartp/Hyprland`, `niri-wm/niri`). Only dgop needs to be built from source with Go.
 
 dankinstall is tested on Workstation Edition but should work fine on any Fedora flavor.
 


### PR DESCRIPTION
Docs still had the old solopasha/hyprland, while the install script now installs from lionheartp/Hyprland.